### PR TITLE
Fix path the the default thumb image

### DIFF
--- a/core/Field/File_Field.php
+++ b/core/Field/File_Field.php
@@ -48,7 +48,7 @@ class File_Field extends Field {
 
 		$url = '';
 		$thumb_url = '';
-		$default_thumb_url = home_url( '/wp-includes/images/media/default.png' );
+		$default_thumb_url = includes_url( '/images/media/default.png' );
 		$file_ext = '';
 		$file_type = '';
 		$value = $this->get_value();


### PR DESCRIPTION
[`home_url()`](https://codex.wordpress.org/Function_Reference/home_url) + "/wp-includes" only works if you have a default WordPress installation. But since you can basically change all paths, it's better to rely on [`includes_url()`](https://codex.wordpress.org/Function_Reference/includes_url) here.