### PR TITLE
Fix for set_options method in the Predefined_Options_Field class

### DIFF
--- a/core/Field/Predefined_Options_Field.php
+++ b/core/Field/Predefined_Options_Field.php
@@ -56,7 +56,7 @@ abstract class Predefined_Options_Field extends Field {
 			$this->options = array();
 			Incorrect_Syntax_Exception::raise( 'Only arrays are allowed in the <code>add_options()</code> method.' );
 		}
-		
+
 		return $this;
 	}
 

--- a/core/Field/Predefined_Options_Field.php
+++ b/core/Field/Predefined_Options_Field.php
@@ -46,12 +46,17 @@ abstract class Predefined_Options_Field extends Field {
 	public function add_options( $options ) {
 		if ( is_array( $options ) ) {
 			$old_options = is_callable( $this->options ) ? array() : $this->options;
-			$this->options = array_merge( $old_options, $options );
+
+			if ( ! empty( $old_options ) ) {
+				$this->options = array_merge( $old_options, $options );
+			} else {
+				$this->options = $options;
+			}
 		} else {
 			$this->options = array();
 			Incorrect_Syntax_Exception::raise( 'Only arrays are allowed in the <code>add_options()</code> method.' );
 		}
-
+		
 		return $this;
 	}
 


### PR DESCRIPTION
The `set_options` method in the `Predefined_Options_Field` class is using `array_merge`. This results in renumbering of the elements of the array, which is not desired in some/most cases. 