### PR TITLE
Fix Nav_Menu_Datastore.php missing dependency in Meta_Datastore.php

### DIFF
--- a/core/Datastore/Meta_Datastore.php
+++ b/core/Datastore/Meta_Datastore.php
@@ -19,8 +19,8 @@ abstract class Meta_Datastore extends Datastore {
 	 * @param Field $field The field to save.
 	 */
 	public function save( Field $field ) {
-		if ( ! update_metadata( $this->get_meta_type(), $this->get_id(), $field->get_name(), $field->get_value() ) ) {
-			add_metadata( $this->get_meta_type(), $this->get_id(), $field->get_name(), $field->get_value(), true );
+		if ( ! update_metadata( $this->get_meta_type(), $this->get_id(), $this->get_field_name($field), $field->get_value() ) ) {
+			add_metadata( $this->get_meta_type(), $this->get_id(), $this->get_field_name($field), $field->get_value(), true );
 		}
 	}
 
@@ -36,7 +36,7 @@ abstract class Meta_Datastore extends Datastore {
 			SELECT `meta_value`
 			FROM ' . $this->get_table_name() . '
 			WHERE `' . $this->get_table_field_name() . '`=' . intval( $this->get_id() ) . '
-			AND `meta_key`="' . $field->get_name() . '"
+			AND `meta_key`="' . $this->get_field_name($field) . '"
 			LIMIT 1
 		' );
 
@@ -54,7 +54,7 @@ abstract class Meta_Datastore extends Datastore {
 	 * @param Field $field The field to delete.
 	 */
 	public function delete( Field $field ) {
-		delete_metadata( $this->get_meta_type(), $this->get_id(), $field->get_name(), $field->get_value() );
+		delete_metadata( $this->get_meta_type(), $this->get_id(), $this->get_field_name($field), $field->get_value() );
 	}
 
 	/**
@@ -66,7 +66,7 @@ abstract class Meta_Datastore extends Datastore {
 		global $wpdb;
 
 		if ( is_object( $field ) && is_subclass_of( $field, 'Carbon_Fields\\Field\\Field' ) ) {
-			$meta_key = $field->get_name();
+			$meta_key = $this->get_field_name($field);
 		} else {
 			$meta_key = $field;
 		}
@@ -86,7 +86,7 @@ abstract class Meta_Datastore extends Datastore {
 		global $wpdb;
 
 		$group_names = $field->get_group_names();
-		$field_name = $field->get_name();
+		$field_name = $this->get_field_name($field);
 
 		$meta_key_constraint = '`meta_key` LIKE "' . $field_name . implode( '-%" OR `meta_key` LIKE "' . $field_name, $group_names ) . '-%"';
 
@@ -94,6 +94,15 @@ abstract class Meta_Datastore extends Datastore {
 			DELETE FROM ' . $this->get_table_name() . '
 			WHERE (' . $meta_key_constraint . ') AND `' . $this->get_table_field_name() . '`="' . intval( $this->get_id() ) . '"
 		' );
+	}
+
+	/**
+	 * Retrieve field name
+	 */
+	public function get_field_name( $field ) {
+		$field_name = $field->get_name();
+
+		return $field_name;
 	}
 
 	/**

--- a/core/Datastore/Meta_Datastore.php
+++ b/core/Datastore/Meta_Datastore.php
@@ -19,8 +19,8 @@ abstract class Meta_Datastore extends Datastore {
 	 * @param Field $field The field to save.
 	 */
 	public function save( Field $field ) {
-		if ( ! update_metadata( $this->get_meta_type(), $this->get_id(), $this->get_field_name($field), $field->get_value() ) ) {
-			add_metadata( $this->get_meta_type(), $this->get_id(), $this->get_field_name($field), $field->get_value(), true );
+		if ( ! update_metadata( $this->get_meta_type(), $this->get_id(), $this->get_field_name( $field ), $field->get_value() ) ) {
+			add_metadata( $this->get_meta_type(), $this->get_id(), $this->get_field_name( $field ), $field->get_value(), true );
 		}
 	}
 
@@ -36,7 +36,7 @@ abstract class Meta_Datastore extends Datastore {
 			SELECT `meta_value`
 			FROM ' . $this->get_table_name() . '
 			WHERE `' . $this->get_table_field_name() . '`=' . intval( $this->get_id() ) . '
-			AND `meta_key`="' . $this->get_field_name($field) . '"
+			AND `meta_key`="' . $this->get_field_name( $field ) . '"
 			LIMIT 1
 		' );
 
@@ -54,7 +54,7 @@ abstract class Meta_Datastore extends Datastore {
 	 * @param Field $field The field to delete.
 	 */
 	public function delete( Field $field ) {
-		delete_metadata( $this->get_meta_type(), $this->get_id(), $this->get_field_name($field), $field->get_value() );
+		delete_metadata( $this->get_meta_type(), $this->get_id(), $this->get_field_name( $field ), $field->get_value() );
 	}
 
 	/**
@@ -66,7 +66,7 @@ abstract class Meta_Datastore extends Datastore {
 		global $wpdb;
 
 		if ( is_object( $field ) && is_subclass_of( $field, 'Carbon_Fields\\Field\\Field' ) ) {
-			$meta_key = $this->get_field_name($field);
+			$meta_key = $this->get_field_name( $field );
 		} else {
 			$meta_key = $field;
 		}
@@ -86,7 +86,7 @@ abstract class Meta_Datastore extends Datastore {
 		global $wpdb;
 
 		$group_names = $field->get_group_names();
-		$field_name = $this->get_field_name($field);
+		$field_name = $this->get_field_name( $field );
 
 		$meta_key_constraint = '`meta_key` LIKE "' . $field_name . implode( '-%" OR `meta_key` LIKE "' . $field_name, $group_names ) . '-%"';
 


### PR DESCRIPTION
Nav Menu fields did not save meta in the correct format.

For example:
It saves `_crb_example-64`, while it should save just `_crb_example`. So when trying to get the nav-menu meta with `carbon_get_post_meta($item->ID, 'crb_example');` - it did not work.