### PR TITLE
Possibility to provide id and label for containers

### DIFF
--- a/core/Container/Comment_Meta_Container.php
+++ b/core/Container/Comment_Meta_Container.php
@@ -15,10 +15,11 @@ class Comment_Meta_Container extends Container {
 	/**
 	 * Create a new comment meta container
 	 *
-	 * @param string $title Unique title of the container
+	 * @param string $id Unique id of the container
+	 * @param string $title Title of the container
 	 **/
-	public function __construct( $title ) {
-		parent::__construct( $title );
+	public function __construct( $id, $title = '' ) {
+		parent::__construct( $id, $title );
 
 		if ( ! $this->get_datastore() ) {
 			$this->set_datastore( new Comment_Meta_Datastore() );

--- a/core/Container/Container.php
+++ b/core/Container/Container.php
@@ -129,10 +129,11 @@ abstract class Container {
 	 * Create a new container of type $type and name $name and label $label.
 	 *
 	 * @param string $type
+	 * @param string $id Unique id of the container
 	 * @param string $name Human-readable name of the container
 	 * @return object $container
 	 **/
-	public static function factory( $type, $name ) {
+	public static function factory( $type, $id, $name = '' ) {
 		// backward compatibility: post_meta container used to be called custom_fields
 		if ( $type === 'custom_fields' ) {
 			$type = 'post_meta';
@@ -147,7 +148,7 @@ abstract class Container {
 			$class = __NAMESPACE__ . '\\Broken_Container';
 		}
 
-		$container = new $class( $name );
+		$container = new $class( $id, $name );
 		$container->type = $type;
 		$container->add_template( $type, array( $container, 'template' ) );
 
@@ -161,8 +162,8 @@ abstract class Container {
 	 *
 	 * @see Container::factory()
 	 **/
-	public static function make( $type, $name ) {
-		return self::factory( $type, $name );
+	public static function make( $type, $id, $name = '' ) {
+		return self::factory( $type, $id, $name );
 	}
 
 	/**
@@ -261,15 +262,20 @@ abstract class Container {
 	/**
 	 * Create a new container
 	 *
-	 * @param string $title Unique title of the container
+	 * @param string $id Unique id of the container
+	 * @param string $title Title of the container
 	 **/
-	public function __construct( $title ) {
+	public function __construct( $id, $title = '' ) {
+		if ( empty( $id ) ) {
+			Incorrect_Syntax_Exception::raise( 'Empty container id is not supported' );
+		}
+
 		if ( empty( $title ) ) {
-			Incorrect_Syntax_Exception::raise( 'Empty container title is not supported' );
+			$title = $id;
 		}
 
 		$this->title = $title;
-		$this->id = preg_replace( '~\W~u', '', remove_accents( $title ) );
+		$this->id = preg_replace( '~\W~u', '', remove_accents( $id ) );
 
 		self::verify_unique_panel_id( $this->id );
 

--- a/core/Container/Post_Meta_Container.php
+++ b/core/Container/Post_Meta_Container.php
@@ -54,10 +54,11 @@ class Post_Meta_Container extends Container {
 	/**
 	 * Create a new post meta fields container
 	 *
-	 * @param string $title Unique title of the container
+	 * @param string $id Unique id of the container
+	 * @param string $title Title of the container
 	 **/
-	public function __construct( $title ) {
-		parent::__construct( $title );
+	public function __construct( $id, $title = '' ) {
+		parent::__construct( $id, $title );
 
 		if ( ! $this->get_datastore() ) {
 			$this->set_datastore( new Post_Meta_Datastore() );

--- a/core/Container/Term_Meta_Container.php
+++ b/core/Container/Term_Meta_Container.php
@@ -20,10 +20,11 @@ class Term_Meta_Container extends Container {
 	/**
 	 * Create a new term meta fields container
 	 *
-	 * @param string $title Unique title of the container
+	 * @param string $id Unique id of the container
+	 * @param string $title Title of the container
 	 **/
-	public function __construct( $title ) {
-		parent::__construct( $title );
+	public function __construct( $id, $title = '' ) {
+		parent::__construct( $id, $title );
 
 		if ( ! $this->get_datastore() ) {
 			$this->set_datastore( new Term_Meta_Datastore() );

--- a/core/Container/Theme_Options_Container.php
+++ b/core/Container/Theme_Options_Container.php
@@ -22,10 +22,11 @@ class Theme_Options_Container extends Container {
 	/**
 	 * Create a new theme options fields container
 	 *
-	 * @param string $title Unique title of the container
+	 * @param string $id Unique id of the container
+	 * @param string $title Title of the container
 	 **/
-	public function __construct( $title ) {
-		parent::__construct( $title );
+	public function __construct( $id, $title = '' ) {
+		parent::__construct( $id, $title );
 
 		if ( ! $this->get_datastore() ) {
 			$this->set_datastore( new Theme_Options_Datastore() );

--- a/core/Container/User_Meta_Container.php
+++ b/core/Container/User_Meta_Container.php
@@ -17,10 +17,11 @@ class User_Meta_Container extends Container {
 	/**
 	 * Create a new user meta container
 	 *
-	 * @param string $title Unique title of the container
+	 * @param string $id Unique id of the container
+	 * @param string $title Title of the container
 	 **/
-	public function __construct( $title ) {
-		parent::__construct( $title );
+	public function __construct( $id, $title = '' ) {
+		parent::__construct( $id, $title );
 
 		if ( ! $this->get_datastore() ) {
 			$this->set_datastore( new User_Meta_Datastore() );

--- a/tests/unit-tests/Container/ContainerInitializationTest.php
+++ b/tests/unit-tests/Container/ContainerInitializationTest.php
@@ -102,8 +102,8 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	public function testNonAsciiContainerTitlesAreHandledProperly() {
 		// This text includes a capital cyrillic letter ... it actually assures that
 		// container titles in non-english are converted to lowercase
-		$container = Container::make('post_meta', 'bulgarian: България');
-		$this->assertEquals('bulgarian: България', $container->id);
+		$container = Container::make('post_meta', $this->containerId, 'bulgarian: България');
+		$this->assertEquals('bulgarian: България', $container->title);
 	}
 	
 	/**

--- a/tests/unit-tests/Container/ContainerInitializationTest.php
+++ b/tests/unit-tests/Container/ContainerInitializationTest.php
@@ -4,6 +4,7 @@ use Carbon_Fields\Exception\Incorrect_Syntax_Exception;
 
 class ContainerInitializationTest extends WP_UnitTestCase {
 	public function setup() {
+		$this->containerId = 'page_settings';
 		$this->containerTitle = 'Page Settings';
 	}
 
@@ -17,7 +18,8 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	 * @covers Carbon_Fields\Container\Container::__construct
 	 */
 	public function testMakePostMetaContainer() {
-		$container = Container::make('post_meta', $this->containerTitle);
+		$container = Container::make('post_meta', $this->containerId, $this->containerTitle);
+        $this->assertEquals($this->containerId, $container->id);
 		$this->assertEquals($this->containerTitle, $container->title);
 	}
 
@@ -30,7 +32,7 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	 * @expectedExceptionMessage Unknown container "".
 	 */
 	public function testExceptionIsThrownWhenContainerTypeIsEmpty() {
-		$container = Container::make('', $this->containerTitle);
+		$container = Container::make('', $this->containerId);
 	}
 
 	/**
@@ -42,7 +44,7 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	 * @expectedExceptionMessage Unknown container "__No_Such_Container_Type__".
 	 */
 	public function testExceptionIsThrownWhenContainerTypeIsInvalid() {
-		$container = Container::make('__no_such_container_type__', $this->containerTitle);
+		$container = Container::make('__no_such_container_type__', $this->containerId);
 	}
 
 	/**
@@ -51,9 +53,9 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	 * @covers Carbon_Fields\Container\Container::__construct
 	 *
 	 * @expectedException Carbon_Fields\Exception\Incorrect_Syntax_Exception
-	 * @expectedExceptionMessage Empty container title is not supported
+	 * @expectedExceptionMessage Empty container id is not supported
 	 */
-	public function testExceptionIsThrownWhenContainerTitleIsEmpty() {
+	public function testExceptionIsThrownWhenContainerIdIsEmpty() {
 		$container = Container::make('post_meta', '');
 	}
 
@@ -66,7 +68,7 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 		$old_val = Incorrect_Syntax_Exception::$throw_errors;
 
 		Incorrect_Syntax_Exception::$throw_errors = false;
-		$container = Container::make('__no_such_container_type__', $this->containerTitle);
+		$container = Container::make('__no_such_container_type__', $this->containerId);
 		$this->assertInstanceOf('Carbon_Fields\Container\Broken_Container', $container);
 
 		Incorrect_Syntax_Exception::$throw_errors = $old_val;
@@ -78,7 +80,7 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	 * @covers Carbon_Fields\Container\Container::__construct
 	 */
 	public function testContainerTypeCaseIsIgnored() {
-		$container = Container::make('Post_Meta', $this->containerTitle);
+		$container = Container::make('Post_Meta', $this->containerId);
 		$this->assertInstanceOf('Carbon_Fields\Container\Post_Meta_Container', $container);
 	}
 
@@ -88,7 +90,7 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	 * @covers Carbon_Fields\Container\Container::__construct
 	 */
 	public function testSpacesInContainerTypeAreSupported() {
-		$container = Container::make('Post Meta', $this->containerTitle);
+		$container = Container::make('Post Meta', $this->containerId);
 		$this->assertTrue(true); // no exception ... 
 	}
 
@@ -101,7 +103,7 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 		// This text includes a capital cyrillic letter ... it actually assures that
 		// container titles in non-english are converted to lowercase
 		$container = Container::make('post_meta', 'bulgarian: България');
-		$this->assertEquals('bulgarian: България', $container->title);
+		$this->assertEquals('bulgarian: България', $container->id);
 	}
 	
 	/**
@@ -110,11 +112,11 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	 * @covers Carbon_Fields\Container\Container::__construct
 	 *
 	 * @expectedException Carbon_Fields\Exception\Incorrect_Syntax_Exception
-	 * @expectedExceptionMessage Panel ID "PageSettings" already registered
+	 * @expectedExceptionMessage Panel ID "page_settings" already registered
 	 */
 	public function testSameContainerNamesAreNotAllowedWithinSameContainerType() {
-		$container1 = Container::make('Post Meta', $this->containerTitle);
-		$container2 = Container::make('Post_Meta', $this->containerTitle);
+		$container1 = Container::make('Post Meta', $this->containerId);
+		$container2 = Container::make('Post_Meta', $this->containerId);
 	}
 
 	/**
@@ -123,11 +125,11 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	 * @covers Carbon_Fields\Container\Container::__construct
 	 *
 	 * @expectedException Carbon_Fields\Exception\Incorrect_Syntax_Exception
-	 * @expectedExceptionMessage Panel ID "PageSettings" already registered
+	 * @expectedExceptionMessage Panel ID "page_settings" already registered
 	 */
 	public function testSameContainerNamesAreNotAllowedAtAll() {
-		$container1 = Container::make('Theme_Options', $this->containerTitle);
-		$container2 = Container::make('User_Meta', $this->containerTitle);
+		$container1 = Container::make('Theme_Options', $this->containerId);
+		$container2 = Container::make('User_Meta', $this->containerId);
 	}
 
 	/**
@@ -136,7 +138,7 @@ class ContainerInitializationTest extends WP_UnitTestCase {
 	 * @covers Carbon_Fields\Container\Container::__construct
 	 */
 	public function testContainerTypeCustomFieldsBackwardsCompatibility() {
-		$container = Container::make('custom_fields', $this->containerTitle);
+		$container = Container::make('custom_fields', $this->containerId);
 		$this->assertInstanceOf('Carbon_Fields\Container\Post_Meta_Container', $container);
 	}
 


### PR DESCRIPTION
Was there a specific reason why it wasn't possible to provide a label for a container (besides to the id)? The current solution doesn't allow to make container labels translatable because they have to be unique. 

In my solution it is possible the provide a `name` besides the `id` of the container. It should be fully backwards compatible since the additional parameter isn't required.
