### PR TITLE
Set post type to page when using page condition methods on containers

### DIFF
--- a/core/Container/Post_Meta_Container.php
+++ b/core/Container/Post_Meta_Container.php
@@ -498,10 +498,13 @@ class Post_Meta_Container extends Container {
 	 * @return object $this
 	 **/
 	public function show_on_template( $template_path ) {
+		$this->show_on_post_type( 'page' );
+
 		if ( is_array( $template_path ) ) {
 			foreach ( $template_path as $path ) {
 				$this->show_on_template( $path );
 			}
+
 			return $this;
 		}
 

--- a/core/Container/Post_Meta_Container.php
+++ b/core/Container/Post_Meta_Container.php
@@ -445,6 +445,7 @@ class Post_Meta_Container extends Container {
 		$page = get_page_by_path( $parent_page_path );
 
 		if ( $page ) {
+			$this->show_on_post_type( 'page' );
 			$this->settings['show_on']['parent_page_id'] = $page->ID;
 		} else {
 			$this->settings['show_on']['parent_page_id'] = -1;

--- a/core/Container/Post_Meta_Container.php
+++ b/core/Container/Post_Meta_Container.php
@@ -468,6 +468,7 @@ class Post_Meta_Container extends Container {
 		}
 
 		if ( $page_obj ) {
+			$this->show_on_post_type( 'page' );
 			$this->settings['show_on']['page_id'] = $page_obj->ID;
 		} else {
 			$this->settings['show_on']['page_id'] = -1;

--- a/tests/unit-tests/Container/PostMetaContainerConditions.php
+++ b/tests/unit-tests/Container/PostMetaContainerConditions.php
@@ -1,0 +1,30 @@
+<?php
+use Carbon_Fields\Container\Container;
+use Carbon_Fields\Container\Post_Meta_Container;
+use Carbon_Fields\Exception\Incorrect_Syntax_Exception;
+
+class PostMetaContainerConditions extends WP_UnitTestCase {
+	public function setUp() {
+		parent::setup();
+
+		$this->containerTitle = 'Page Settings';
+		$this->page = get_post( $this->factory->post->create( array( 'post_type' => 'page' ) ) );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		Container::$registered_panel_ids = array();
+		unset( $this->page );
+	}
+
+	/**
+	 * @covers Carbon_Fields\Container\Post_Meta_Container::show_on_page_children
+	 */
+	public function testShowOnPageChildrenResultPostType() {
+		$container = Container::make('post_meta', $this->containerTitle);
+		$container->show_on_page_children( $this->page->post_name );
+		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
+	}
+
+}

--- a/tests/unit-tests/Container/PostMetaContainerConditions.php
+++ b/tests/unit-tests/Container/PostMetaContainerConditions.php
@@ -45,4 +45,22 @@ class PostMetaContainerConditions extends WP_UnitTestCase {
 		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
 	}
 
+	/**
+	 * @covers Carbon_Fields\Container\Post_Meta_Container::show_on_template
+	 */
+	public function testShowOnTemplateStringResultPostType() {
+		$container = Container::make('post_meta', $this->containerTitle);
+		$container->show_on_template( 'default' );
+		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
+	}
+
+	/**
+	 * @covers Carbon_Fields\Container\Post_Meta_Container::show_on_template
+	 */
+	public function testShowOnTemplateArrayResultPostType() {
+		$container = Container::make('post_meta', $this->containerTitle);
+		$container->show_on_template( array( 'default' ) );
+		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
+	}
+
 }

--- a/tests/unit-tests/Container/PostMetaContainerConditions.php
+++ b/tests/unit-tests/Container/PostMetaContainerConditions.php
@@ -27,4 +27,22 @@ class PostMetaContainerConditions extends WP_UnitTestCase {
 		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
 	}
 
+	/**
+	 * @covers Carbon_Fields\Container\Post_Meta_Container::show_on_page
+	 */
+	public function testShowOnPageByIdResultPostType() {
+		$container = Container::make('post_meta', $this->containerTitle);
+		$container->show_on_page( $this->page->ID );
+		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
+	}
+
+	/**
+	 * @covers Carbon_Fields\Container\Post_Meta_Container::show_on_page
+	 */
+	public function testShowOnPageByPathResultPostType() {
+		$container = Container::make('post_meta', $this->containerTitle);
+		$container->show_on_page( $this->page->post_name );
+		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
+	}
+
 }


### PR DESCRIPTION
This is a solution of https://github.com/htmlburger/carbon-fields/issues/24.

When using `show_on_page()`, `show_on_template()` and `show_on_page_children()` on a `Post_Meta` container, the post type was not being changed to `page` automatically.

This was requiring that users specifically call `->show_on_post_type( 'page' )` in order for the container to be actually shown.

This PR addresses this issue for the 3 specified methods above. 

Tests are also included.