### PR TITLE
Fixes warning in set_header_template.

### DIFF
--- a/core/Field/Complex_Field.php
+++ b/core/Field/Complex_Field.php
@@ -97,7 +97,8 @@ class Complex_Field extends Field {
 		$template = is_callable( $template ) ? call_user_func( $template ) : $template;
 
 		// Assign the template to the group that was added last
-		$group = end( array_values( $this->groups ) );
+		$values = array_values( $this->groups );
+		$group = end( $values );
 		$group->set_label_template( $template );
 
 		// Include the group label Underscore template


### PR DESCRIPTION
Moves 'array_values' function outside of 'end' function.

Original warning before fix: 
Strict standards: Only variables should be passed by reference in PATH\TO\wp-content\plugins\carbon-fields\core\Field\Complex_Field.php on line 100