### PR TITLE
set id on each field's datastore before save and before retrieval

### DIFF
--- a/core/Container/Post_Meta_Container.php
+++ b/core/Container/Post_Meta_Container.php
@@ -112,6 +112,10 @@ class Post_Meta_Container extends Container {
 	public function init() {
 		if ( isset( $_GET['post'] ) ) {
 			$this->set_post_id( $_GET['post'] );
+			foreach ( $this->fields as $field ) {
+				$datastore = $field->get_datastore();
+				$datastore->set_id($_GET['post']);
+			}
 		}
 
 		// force post_type to be array
@@ -140,6 +144,8 @@ class Post_Meta_Container extends Container {
 		$this->set_post_id( $post_id );
 
 		foreach ( $this->fields as $field ) {
+			$datastore = $field->get_datastore();
+			$datastore->set_id($post_id);
 			$field->set_value_from_input();
 			$field->save();
 		}


### PR DESCRIPTION
Technically each field can have it's own datastore instance. This might be useful when I want to use a common field like 'text' or 'relationship' and provide it with a custom saving-strategy. I would then setup up the field as normal and call the set_datastore method, passing an instance of my custom datastore. 
However, the Post_Meta_Container Class assumes that all fields within a container have the same datastore instance. Thus, when the container's init method or save method is invoked only the container's datastore instance is being prepared. The set_id method of the datastore interface is only invoked on the container's datastore and not on the field's datastores. This commit is a quick fix for that.
