### PR TITLE
Allow show_on_page to use string representation of numbers

### DIFF
--- a/core/Container/Post_Meta_Container.php
+++ b/core/Container/Post_Meta_Container.php
@@ -461,7 +461,7 @@ class Post_Meta_Container extends Container {
 	 * @return object $this
 	 **/
 	public function show_on_page( $page ) {
-		if ( is_int( $page ) ) {
+		if ( absint( $page ) == $page ) {
 			$page_obj = get_post( $page );
 		} else {
 			$page_obj = get_page_by_path( $page );


### PR DESCRIPTION
Right now the `->show_on_page($page_path|$page_id)` method for `Post_Meta_Container` requires to explicitly provide an integer in case you'd like to use a page ID.

It would be nice if you can use directly functions like `get_option()`, which return a string.