### PR TITLE
Static groups

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -373,7 +373,9 @@ body.comment-php #poststuff .postbox-container .inside { margin: 0; padding: 0; 
 			transform: rotate(180deg) translateX(-1px) translateY(-2px);
 }
 
-.groups-wrapper.layout-tabbed-horizontal .carbon-group-row.static .fields-container:after {  height: 0;  border-top: none; }
+.carbon-subcontainer.static > .groups-wrapper.layout-tabbed-horizontal  > .carbon-groups-holder > .carbon-group-row > .fields-container:after {  height: 0;  border-top: none; }
+.carbon-subcontainer.static > .groups-wrapper > .carbon-groups-holder > .carbon-group-row > .carbon-group-actions .carbon-btn-duplicate,
+.carbon-subcontainer.static > .groups-wrapper > .carbon-groups-holder > .carbon-group-row > .carbon-group-actions .carbon-btn-remove {  display: none; }
 
 /* Tabs */
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -373,6 +373,7 @@ body.comment-php #poststuff .postbox-container .inside { margin: 0; padding: 0; 
 			transform: rotate(180deg) translateX(-1px) translateY(-2px);
 }
 
+.groups-wrapper.layout-tabbed-horizontal .carbon-group-row.static .fields-container:after {  height: 0;  border-top: none; }
 
 /* Tabs */
 

--- a/assets/js/fields.js
+++ b/assets/js/fields.js
@@ -1688,6 +1688,7 @@ window.carbon = window.carbon || {};
 
 			this.multipleGroups = this.model.get('multiple_groups');
 			this.isTabbed = this.model.isTabbed();
+			this.isStatic = this.model.get('static');
 
 			/*
 			 * Groups Collection
@@ -1747,8 +1748,12 @@ window.carbon = window.carbon || {};
 			// Group Tabs initialization
 			if (this.isTabbed) {
 				this.model.addClass('carbon-Complex-tabbed');
-				
 				this.on('field:rendered', this.initGroupTabs);
+			}
+
+			// Render the groups as static ones without add or remove actions
+			if(this.isStatic) {
+				this.on('field:rendered', this.renderStaticGroups);
 			}
 		},
 
@@ -1866,6 +1871,23 @@ window.carbon = window.carbon || {};
 
 					ui.item.groupView.trigger('sortable', event);
 				}
+			});
+		},
+
+		renderStaticGroups: function() {
+			var _this = this;
+			var groups = this.model.get('groups') || [];
+
+			_.each(groups, function(group) {
+				var contains = _.some(_this.groupsCollection.model, function(model) {
+					return model.attributes.name == group.name;
+				});
+
+				if(!contains) {
+					_this.addNewGroup(group.name);
+				}
+			}, function(){
+				_this.model.set('value', _this.groupsCollection.toJSON());
 			});
 		},
 

--- a/core/Field/Complex_Field.php
+++ b/core/Field/Complex_Field.php
@@ -24,6 +24,7 @@ class Complex_Field extends Field {
 	protected $groups = array();
 
 	protected $layout = self::LAYOUT_GRID;
+	public $static = false;
 	protected $values_min = -1;
 	protected $values_max = -1;
 
@@ -401,6 +402,7 @@ class Complex_Field extends Field {
 				'name' => $group->get_name(),
 				'label' => $group->get_label(),
 				'group_id' => $group->get_group_id(),
+				'static' => $this->static,
 				'fields' => array(),
 			);
 
@@ -413,9 +415,10 @@ class Complex_Field extends Field {
 
 		$complex_data = array_merge( $complex_data, array(
 			'layout' => $this->layout,
+			'static' => $this->static,
 			'labels' => $this->labels,
-			'min' => $this->get_min(),
-			'max' => $this->get_max(),
+			'min' => $this->static ? count( $groups_data ) : $this->get_min(),
+			'max' => $this->static ? count( $groups_data ) : $this->get_max(),
 			'multiple_groups' => count( $groups_data ) > 1,
 			'groups' => $groups_data,
 			'value' => $values_data,
@@ -486,7 +489,7 @@ class Complex_Field extends Field {
 	 */
 	public function template_group() {
 		?>
-		<div id="carbon-{{{ complex_name }}}-complex-container" class="carbon-row carbon-group-row" data-group-id="{{ id }}">
+		<div id="carbon-{{{ complex_name }}}-complex-container" class="carbon-row carbon-group-row {{ static ? 'static' : '' }}" data-group-id="{{ id }}">
 			<input type="hidden" name="{{{ complex_name + '[' + index + ']' }}}[group]" value="{{ name }}" />
 
 			<div class="carbon-drag-handle">
@@ -495,16 +498,18 @@ class Complex_Field extends Field {
 
 			<div class="carbon-group-actions">
 				<a class="carbon-btn-collapse" href="#" title="<?php esc_attr_e( 'Collapse/Expand', 'carbon_fields' ); ?>">
-					<?php _e( 'Collapse/Expand', 'carbon_fields' ); ?>
+					<?php _e( 'Collapse/Expand', 'carbon_fields' ); ?> {{{ fields.static }}}
 				</a>
 
-				<a class="carbon-btn-duplicate" href="#" title="<?php esc_attr_e( 'Clone', 'carbon_fields' ); ?>">
-					<?php _e( 'Clone', 'carbon_fields' ); ?>
-				</a>
+				<# if (!static) { #>
+					<a class="carbon-btn-duplicate" href="#" title="<?php esc_attr_e( 'Clone', 'carbon_fields' ); ?>">
+						<?php _e( 'Clone', 'carbon_fields' ); ?>
+					</a>
 
-				<a class="carbon-btn-remove" href="#" title="<?php esc_attr_e( 'Remove', 'carbon_fields' ); ?>">
-					<?php _e( 'Remove', 'carbon_fields' ); ?>
-				</a>
+					<a class="carbon-btn-remove" href="#" title="<?php esc_attr_e( 'Remove', 'carbon_fields' ); ?>">
+						<?php _e( 'Remove', 'carbon_fields' ); ?>
+					</a>
+				<# } #>
 			</div>
 
 			<div class="fields-container">
@@ -557,6 +562,7 @@ class Complex_Field extends Field {
 	 * Modify the layout of this field.
 	 *
 	 * @param string $layout
+	 * @return Complex_Field
 	 */
 	public function set_layout( $layout ) {
 		$available_layouts = array(
@@ -591,9 +597,23 @@ class Complex_Field extends Field {
 	}
 
 	/**
+	 * Set the complex fields to static.
+	 * If you set the type to static, there will be no options to add or remove any group.
+	 * Min and max values are going to be ignored.
+	 *
+	 * @param string $static
+	 * @return Complex_Field
+	 */
+	public function set_static($static) {
+		$this->static = $static;
+		return $this;
+	}
+
+	/**
 	 * Set the minimum number of entries.
 	 *
 	 * @param int $min
+	 * @return Complex_Field
 	 */
 	public function set_min( $min ) {
 		$this->values_min = intval( $min );
@@ -613,6 +633,7 @@ class Complex_Field extends Field {
 	 * Set the maximum number of entries.
 	 *
 	 * @param int $max
+	 * @return Complex_Field
 	 */
 	public function set_max( $max ) {
 		$this->values_max = intval( $max );

--- a/core/Field/Complex_Field.php
+++ b/core/Field/Complex_Field.php
@@ -432,7 +432,7 @@ class Complex_Field extends Field {
 	 */
 	public function template() {
 		?>
-		<div class="carbon-subcontainer carbon-grid {{ multiple_groups ? 'multiple-groups' : '' }}">
+		<div class="carbon-subcontainer carbon-grid {{ multiple_groups ? 'multiple-groups' : '' }} {{ static ? 'static' : '' }}">
 			<div class="carbon-empty-row">
 				{{{ crbl10n.complex_no_rows.replace('%s', labels.plural_name) }}}
 			</div>
@@ -489,7 +489,7 @@ class Complex_Field extends Field {
 	 */
 	public function template_group() {
 		?>
-		<div id="carbon-{{{ complex_name }}}-complex-container" class="carbon-row carbon-group-row {{ static ? 'static' : '' }}" data-group-id="{{ id }}">
+		<div id="carbon-{{{ complex_name }}}-complex-container" class="carbon-row carbon-group-row" data-group-id="{{ id }}">
 			<input type="hidden" name="{{{ complex_name + '[' + index + ']' }}}[group]" value="{{ name }}" />
 
 			<div class="carbon-drag-handle">
@@ -501,15 +501,13 @@ class Complex_Field extends Field {
 					<?php _e( 'Collapse/Expand', 'carbon_fields' ); ?>
 				</a>
 
-				<# if (!static) { #>
-					<a class="carbon-btn-duplicate" href="#" title="<?php esc_attr_e( 'Clone', 'carbon_fields' ); ?>">
-						<?php _e( 'Clone', 'carbon_fields' ); ?>
-					</a>
+				<a class="carbon-btn-duplicate" href="#" title="<?php esc_attr_e( 'Clone', 'carbon_fields' ); ?>">
+					<?php _e( 'Clone', 'carbon_fields' ); ?>
+				</a>
 
-					<a class="carbon-btn-remove" href="#" title="<?php esc_attr_e( 'Remove', 'carbon_fields' ); ?>">
-						<?php _e( 'Remove', 'carbon_fields' ); ?>
-					</a>
-				<# } #>
+				<a class="carbon-btn-remove" href="#" title="<?php esc_attr_e( 'Remove', 'carbon_fields' ); ?>">
+					<?php _e( 'Remove', 'carbon_fields' ); ?>
+				</a>
 			</div>
 
 			<div class="fields-container">

--- a/core/Field/Complex_Field.php
+++ b/core/Field/Complex_Field.php
@@ -498,7 +498,7 @@ class Complex_Field extends Field {
 
 			<div class="carbon-group-actions">
 				<a class="carbon-btn-collapse" href="#" title="<?php esc_attr_e( 'Collapse/Expand', 'carbon_fields' ); ?>">
-					<?php _e( 'Collapse/Expand', 'carbon_fields' ); ?> {{{ fields.static }}}
+					<?php _e( 'Collapse/Expand', 'carbon_fields' ); ?>
 				</a>
 
 				<# if (!static) { #>


### PR DESCRIPTION
Hey there,
what do you think about static groups? Static groups are pre-rendered groups without any add or remove action. I'm working on an affiliate e-commerce project and if you define a product in my case, you now that there will be just 2 attribute groups for instance - not more or less.

I made this PR because I think there are some more developers who can benefit from this feature.

Here is an example (take a closer look on `set_static()`:

``` php
Container::make('post_meta', 'Custom Data')
             ->show_on_post_type('page')
             ->add_fields(array(
                 Field::make('complex', 'crb_job')
                      ->set_layout('tabbed')
                      ->set_static(true)
                      ->add_fields('driver', 'Driver', array(
                          Field::make('text', 'name'),
                          Field::make('text', 'drivers_license_id'),
                      ))
                     ->add_fields('teacher', 'Teacher', array(
                         Field::make('image', 'name'),
                         Field::make('image', 'years_of_experience'),
                     )),
             ));
```

<img width="800" alt="screenshot 2016-10-18 12 48 23" src="https://cloud.githubusercontent.com/assets/7062807/19475052/736164c6-9532-11e6-9626-7d368f1aec92.png">

<img width="794" alt="screenshot 2016-10-18 13 00 59" src="https://cloud.githubusercontent.com/assets/7062807/19475160/f40ef5ac-9532-11e6-8076-ed2700db00a5.png">

Best regard,
Alexander Barton
