### PR TITLE
Remove files from autoload (fixes #114)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,10 +85,6 @@
     "autoload": {
         "psr-4": {
             "Carbon_Fields\\": "core/"
-        },
-        "files": [
-            "carbon-fields.php",
-            "core/functions.php"
-        ]
+        }
     }
 }


### PR DESCRIPTION
These files are required in carbon-fields-plugin.php anyway and causes a fatal error in set ups where autoload.php is loaded before WordPress.