### PR TITLE
Add `collapse()` method for complex fields

### DIFF
--- a/assets/js/fields.js
+++ b/assets/js/fields.js
@@ -2078,7 +2078,7 @@ window.carbon = window.carbon || {};
 		defaults: {
 			'order': null,
 			'index': null,
-			'collapsed': false
+			'collapsed': null
 		},
 
 		initialize: function() {
@@ -2362,7 +2362,7 @@ window.carbon = window.carbon || {};
 
 			var attributes = $.extend(true, {}, this.model.attributes);
 			attributes.id = null;
-			attributes.collapsed = false;
+			attributes.collapsed = this.model.get('collapsed');
 
 			if (attributes.hasOwnProperty('fields')) {
 				attributes.fields = this.fieldsCollection.toJSON();
@@ -2377,6 +2377,15 @@ window.carbon = window.carbon || {};
 
 		afterRenderInit: function() {
 			var _this = this;
+
+			// Initialize the local `collapsed` value with `collapsed` value defined in PHP land
+			// If it's already set is because it's a duplicate row
+			if (this.model.get('collapsed') === null) {
+				this.model.set('collapsed', this.complexModel.get('collapsed'));
+			}
+
+			// Update collapse state/visibility
+			this.toggleCollapse(this.model);
 
 			// Trigger the add event on the collection, this should initialize the fields rendering
 			this.fieldsCollection.each(function(model) {

--- a/assets/js/fields.js
+++ b/assets/js/fields.js
@@ -1821,6 +1821,10 @@ window.carbon = window.carbon || {};
 			var groups = this.model.get('value');
 
 			_.each(groups, function(group) {
+				// Set the value defined by the user in PHP land
+				// This code will run only the first time that the groups are created
+				group.collapsed = _this.model.get('collapsed');
+				
 				_this.groupsCollection.add(group, {
 					sort: false
 				});
@@ -1929,16 +1933,13 @@ window.carbon = window.carbon || {};
 
 			var view = carbon.views[id] = new carbon.fields.View.Complex.Group({
 				el: this.$groupsHolder,
-				model: model,
-				attributes: {
-					collapsed: this.model.get('collapsed')
-				}
+				model: model
 			});
 
 			view.on('layoutUpdated', function() {
 				_this.trigger('layoutUpdated');
 			});
-console.log(this.model.get('collapsed'));
+
 			view.render(this.model);
 
 			return this;
@@ -2086,7 +2087,7 @@ console.log(this.model.get('collapsed'));
 
 		initialize: function() {
 			var fields = this.get('fields');
-console.log(this);
+
 			_.each(fields, function(field) {
 				if (field.hasOwnProperty('old_id') && field.hasOwnProperty('old_name')) {
 					field.id = field.old_id;

--- a/assets/js/fields.js
+++ b/assets/js/fields.js
@@ -1929,13 +1929,16 @@ window.carbon = window.carbon || {};
 
 			var view = carbon.views[id] = new carbon.fields.View.Complex.Group({
 				el: this.$groupsHolder,
-				model: model
+				model: model,
+				attributes: {
+					collapsed: this.model.get('collapsed')
+				}
 			});
 
 			view.on('layoutUpdated', function() {
 				_this.trigger('layoutUpdated');
 			});
-
+console.log(this.model.get('collapsed'));
 			view.render(this.model);
 
 			return this;
@@ -2078,12 +2081,12 @@ window.carbon = window.carbon || {};
 		defaults: {
 			'order': null,
 			'index': null,
-			'collapsed': null
+			'collapsed': false
 		},
 
 		initialize: function() {
 			var fields = this.get('fields');
-
+console.log(this);
 			_.each(fields, function(field) {
 				if (field.hasOwnProperty('old_id') && field.hasOwnProperty('old_name')) {
 					field.id = field.old_id;
@@ -2362,7 +2365,7 @@ window.carbon = window.carbon || {};
 
 			var attributes = $.extend(true, {}, this.model.attributes);
 			attributes.id = null;
-			attributes.collapsed = this.model.get('collapsed');
+			attributes.collapsed = false;
 
 			if (attributes.hasOwnProperty('fields')) {
 				attributes.fields = this.fieldsCollection.toJSON();
@@ -2377,12 +2380,6 @@ window.carbon = window.carbon || {};
 
 		afterRenderInit: function() {
 			var _this = this;
-
-			// Initialize the local `collapsed` value with `collapsed` value defined in PHP land
-			// If it's already set is because it's a duplicate row
-			if (this.model.get('collapsed') === null) {
-				this.model.set('collapsed', this.complexModel.get('collapsed'));
-			}
 
 			// Update collapse state/visibility
 			this.toggleCollapse(this.model);

--- a/core/Field/Complex_Field.php
+++ b/core/Field/Complex_Field.php
@@ -26,6 +26,7 @@ class Complex_Field extends Field {
 	protected $layout = self::LAYOUT_GRID;
 	protected $values_min = -1;
 	protected $values_max = -1;
+	protected $collapsed = false;
 
 	public $labels = array(
 		'singular_name' => 'Entry',
@@ -419,6 +420,7 @@ class Complex_Field extends Field {
 			'multiple_groups' => count( $groups_data ) > 1,
 			'groups' => $groups_data,
 			'value' => $values_data,
+			'collapsed' => $this->collapsed,
 		) );
 
 		return $complex_data;
@@ -479,6 +481,15 @@ class Complex_Field extends Field {
 			</div>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Collapse the complex field entries.
+	 */
+	public function collapse() {
+		$this->collapsed = true;
+
+		return $this;
 	}
 
 	/**

--- a/core/Field/Complex_Field.php
+++ b/core/Field/Complex_Field.php
@@ -486,8 +486,8 @@ class Complex_Field extends Field {
 	/**
 	 * Collapse the complex field entries.
 	 */
-	public function collapse() {
-		$this->collapsed = true;
+	public function collapse( $state = true ) {
+		$this->collapsed = $state;
 
 		return $this;
 	}


### PR DESCRIPTION
Resolves #44. When `collapse()` is called for a complex field all its child _groups_ will be collapsed. Great for compact interfaces.