### PR TITLE
Radio image field

### DIFF
--- a/assets/js/fields.js
+++ b/assets/js/fields.js
@@ -924,7 +924,42 @@ window.carbon = window.carbon || {};
 		}
 	});
 
+    	/*--------------------------------------------------------------------------
+	 * RADIO IMAGE
+	 *------------------------------------------------------------------------*/
 
+    	// RadioImage VIEW
+	carbon.fields.View.RadioImage = carbon.fields.View.extend({
+	    initialize: function () {
+	        carbon.fields.View.prototype.initialize.apply(this);
+
+            //Adds the 'selected' class to the parent li of checked input, on fields render event
+	        this.on('field:rendered', this.updateChecked);
+	    },
+
+	    sync: function (event) {
+	        var $radio = this.$('input[type="radio"]:checked');
+	        
+	        if ($radio.length) {
+	            $radio.parents('ul').children('li.selected').removeClass('selected');
+	            $radio.parents('li').addClass('selected');
+	        }
+	        else {
+	            $radio.parents('ul').children('li.selected').removeClass('selected');
+	        }
+
+	        this.model.set('value', value);
+	    },
+
+	    updateChecked: function () {
+	        var $radio = this.$('input[type="radio"]:checked');
+
+	        if ($radio.length) {
+	            $radio.parents('li').addClass('selected');
+	        }
+	    }
+	});
+	
 	/*--------------------------------------------------------------------------
 	 * GRAVITY FORM
 	 *------------------------------------------------------------------------*/

--- a/assets/postcss/modules/_field.radioimage.css
+++ b/assets/postcss/modules/_field.radioimage.css
@@ -1,0 +1,8 @@
+/* ------------------------------------------------------------ *\
+	Field - Radio Image
+\* ------------------------------------------------------------ */
+
+.carbon-field .carbon-radio-image-list li { display:inline-block; padding: 5px; }
+.carbon-field .carbon-radio-image-list input[type="radio"] { display: none; }
+.carbon-field .carbon-radio-image-list label { display: block; padding: 3px; border-radius: 4px; }
+.carbon-field .carbon-radio-image-list .selected label { display: block; box-shadow: inset 0 0 3px 1px #00a0d2 }

--- a/core/Field/Radio_Image_Field.php
+++ b/core/Field/Radio_Image_Field.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Carbon_Fields\Field;
+
+/**
+ * Images as radio buttons field class.
+ */
+class Radio_Image_Field extends Predefined_Options_Field {
+	/**
+     * Check if there are callbacks and populate the options
+     * Overrided to not modify the field options
+     */
+	protected function load_options() {
+		if ( empty( $this->options ) ) {
+			return false;
+		}
+
+        $options = $this->options;
+
+		if ( is_callable( $options ) ) {
+			$options = call_user_func( $options );
+			if ( ! is_array( $options ) ) {
+				$options = array();
+			}
+		}
+
+		$this->options = $options;
+	}
+
+	/**
+     * Changes the options array structure. This is needed to keep the array items order when it is JSON encoded.
+     * Will also work with a callable that returns an array.
+     * Overrided to prevent losing other data in an option array
+     *
+     * @param array|callable $options
+     * @return array
+     */
+	public function parse_options( $options ) {
+		$parsed = array();
+
+		if ( is_callable( $options ) ) {
+			$options = call_user_func( $options );
+		}
+
+        foreach ( $options as $item ) {
+            $tmp = $item['name'];
+            $item['name'] = $item['value'];
+            $item['value'] = $tmp;
+            $parsed[] = $item;
+		}
+
+		return $parsed;
+	}
+
+    /**
+     * Returns an array that holds the field data, suitable for JSON representation.
+     * This data will be available in the Underscore template and the Backbone Model.
+     *
+     * @param bool $load  Should the value be loaded from the database or use the value from the current instance.
+     * @return array
+     */
+	public function to_json( $load ) {
+		$field_data = parent::to_json( $load );
+		$this->load_options();
+
+		$field_data = array_merge( $field_data, array(
+			'options' => $this->parse_options( $this->options ),
+		) );
+
+		return $field_data;
+	}
+
+	/**
+     * The main Underscore template of this field.
+     */
+	public function template() {
+?>
+		<# if (_.isEmpty(options)) { #>
+			<em><?php _e( 'no options', 'carbon-fields' ); ?></em>
+		<# } else { #>
+			<ul class="carbon-radio-list carbon-radio-image-list">
+				<# _.each(options, function(option) { #>
+					<li>
+						<label>
+                            <img class="carbon-radio-image" src="{{{ option.imgUrl }}}" title="{{{ option.name }}}">
+							<input type="radio" name="{{{ name }}}" value="{{ option.value }}" {{{ option.value == value ? 'checked="checked"' : '' }}} />
+						</label>
+					</li>
+				<# }) #>
+			</ul>
+		<# } #>
+		<?php
+	}
+}


### PR DESCRIPTION
I have created a field for showing images instead of radio inputs to the user. This field can be used this way:

```
Field::make("radio_image", "crb_image_radio_field", __('Choose an option'))
        ->add_options(array(
            array(
                'name' => 'myoption1',
                'value' => 'Some string',
                'imgUrl' => get_template_directory_url() . '/images/some-image1.png'
            ),
            array(
                'name' => 'myoption2',
                'value' => 'Some string',
                'imgUrl' => get_template_directory_url() . '/images/some-image2.png'
            ),
            array(
                'name' => 'myoption3',
                'value' => 'Some string',
                'imgUrl' => get_template_directory_url() . '/images/some-image3.png'
            ),
        ))
        ->set_default_value('myoption3')
     ));
```

I only tested it on posts.