### PR TITLE
WordPress 4.7 compatibility update

### DIFF
--- a/assets/js/containers.js
+++ b/assets/js/containers.js
@@ -634,18 +634,16 @@ window.carbon = window.carbon || {};
 				switch(type) {
 					case 'template_names':
 						var template = _this.model.get('page_template');
-						var isPage = typeof typenow !== 'undefined' && typenow === 'page';
 
-						if (isPage && $.inArray(template, req) === -1) {
+						if ($.inArray(template, req) === -1) {
 							visible = false;
 						}
 					break;
 
 					case 'not_in_template_names':
 						var template = _this.model.get('page_template');
-						var isPage = typeof typenow !== 'undefined' && typenow === 'page';
 						
-						if (isPage && $.inArray(template, req) !== -1) {
+						if ($.inArray(template, req) !== -1) {
 							visible = false;
 						}
 					break;

--- a/core/Container/Post_Meta_Container.php
+++ b/core/Container/Post_Meta_Container.php
@@ -456,8 +456,6 @@ class Post_Meta_Container extends Container {
 	 * @return object $this
 	 **/
 	public function show_on_template( $template_path ) {
-		$this->show_on_post_type( 'page' );
-
 		if ( is_array( $template_path ) ) {
 			foreach ( $template_path as $path ) {
 				$this->show_on_template( $path );

--- a/tests/unit-tests/Container/PostMetaContainerConditions.php
+++ b/tests/unit-tests/Container/PostMetaContainerConditions.php
@@ -69,7 +69,7 @@ class PostMetaContainerConditions extends WP_UnitTestCase {
 	public function testShowOnTemplateStringResultPostType() {
 		$container = Container::make('post_meta', $this->containerTitle);
 		$container->show_on_template( 'default' );
-		$container->set_post_type( 'page' );
+		$container->show_on_post_type( 'page' );
 		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
 	}
 
@@ -79,7 +79,7 @@ class PostMetaContainerConditions extends WP_UnitTestCase {
 	public function testShowOnTemplateArrayResultPostType() {
 		$container = Container::make('post_meta', $this->containerTitle);
 		$container->show_on_template( array( 'default' ) );
-		$container->set_post_type( 'page' );
+		$container->show_on_post_type( 'page' );
 		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
 	}
 

--- a/tests/unit-tests/Container/PostMetaContainerConditions.php
+++ b/tests/unit-tests/Container/PostMetaContainerConditions.php
@@ -69,6 +69,7 @@ class PostMetaContainerConditions extends WP_UnitTestCase {
 	public function testShowOnTemplateStringResultPostType() {
 		$container = Container::make('post_meta', $this->containerTitle);
 		$container->show_on_template( 'default' );
+		$container->set_post_type( 'page' );
 		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
 	}
 
@@ -78,6 +79,7 @@ class PostMetaContainerConditions extends WP_UnitTestCase {
 	public function testShowOnTemplateArrayResultPostType() {
 		$container = Container::make('post_meta', $this->containerTitle);
 		$container->show_on_template( array( 'default' ) );
+		$container->set_post_type( 'page' );
 		$this->assertSame( array( 'page' ), $container->settings['post_type'] );
 	}
 


### PR DESCRIPTION
Since WP 4.7 Templates will be allowed on custom post types as well. This change reflects that, by removing the enforcement for `page` post type when using `show_on_template`.

_(Potentially this could cause compatibility issue with containers defined without `show_on_post_type`, that relies on this line of code. This is minor issue, and should not cause issues.)_