### PR TITLE
WordPress 4.7 Compatibility update

### DIFF
--- a/core/Walker/Nav_Menu_Edit_Walker.php
+++ b/core/Walker/Nav_Menu_Edit_Walker.php
@@ -23,12 +23,27 @@ class Nav_Menu_Edit_Walker extends \Walker_Nav_Menu_Edit {
 
 		$flag = '<!--CarbonFields-->';
 
+		// Generates the HTML
 		ob_start();
 		do_action( 'crb_print_carbon_container_nav_menu_fields_html', $item, $output, $depth, $args, $id );
 		echo $flag;
 		$fields = ob_get_clean();
 
-		$marker = '<p class="field-move hide-if-no-js description description-wide">';
-		$output = preg_replace( '~(?<!' . preg_quote( $flag, '~' ) . ')' . preg_quote( $marker, '~' ) . '~', $fields . $marker, $output );
+		// List of possible insertion markers, this may vary between WP Core versions
+		$markers = array(
+			preg_quote( '<p class="field-move hide-if-no-js description description-wide">' ),
+			preg_quote( '<fieldset class="field-move hide-if-no-js description description-wide">' ),
+		);
+
+		// Build the regex
+		$regex = sprintf(
+			'~(?<!%s)(%s)~',
+			preg_quote( $flag, '~' ),
+			implode( '|', $markers)
+		);
+
+		// Injects the HTML
+		$output = preg_replace( $regex, $fields . "$1", $output );
 	}
+
 }

--- a/core/Walker/Nav_Menu_Edit_Walker.php
+++ b/core/Walker/Nav_Menu_Edit_Walker.php
@@ -31,7 +31,9 @@ class Nav_Menu_Edit_Walker extends \Walker_Nav_Menu_Edit {
 
 		// List of possible insertion markers, this may vary between WP Core versions
 		$markers = array(
+			# WordPress < 4.7
 			preg_quote( '<p class="field-move hide-if-no-js description description-wide">' ),
+			# WordPress 4.7
 			preg_quote( '<fieldset class="field-move hide-if-no-js description description-wide">' ),
 		);
 


### PR DESCRIPTION
Updating Nav Menu Container compatibility for `4.7`, while keeping things backward compatible with core versions before `<4.7`.

This fixes issue #150 