### PR TITLE
Don't save empty fields inside complex

### DIFF
--- a/core/Field/Complex_Field.php
+++ b/core/Field/Complex_Field.php
@@ -196,6 +196,7 @@ class Complex_Field extends Field {
 				// set value from the group
 				$tmp_field = clone $field;
 				if ( is_a( $tmp_field, __NAMESPACE__ . '\\Complex_Field' ) ) {
+
 					if ( ! isset( $values[ $tmp_field->get_name() ] ) ) {
 						continue; // bail if the complex field is empty
 					}
@@ -206,6 +207,14 @@ class Complex_Field extends Field {
 					$tmp_field->set_name( $new_name );
 					$tmp_field->set_value_from_input( $new_values );
 				} else {
+          if ( ! isset( $values[ $tmp_field->get_name() ] ) ) {
+						continue; // bail if the field is empty
+					}
+
+          if ( $tmp_field->type === 'Rich_Text' && empty( $values[ $tmp_field->get_name() ] ) ) {
+            continue; // bail if the field is empty
+          }
+
 					$tmp_field->set_value_from_input( $values );
 				}
 


### PR DESCRIPTION
Prevents saving empty fields inside complex field. This kind of situation can happen when there is fields with conditional logic.

PR relates to #47 and needs testing.