### PR TITLE
Integrate show_for method for User Meta Container

### DIFF
--- a/core/Container/User_Meta_Container.php
+++ b/core/Container/User_Meta_Container.php
@@ -124,10 +124,10 @@ class User_Meta_Container extends Container {
 	 **/
 	public function show_for( $show_for ) {
 		// Filter empty values and unexpected attributes
-		$show_for = shortcode_atts( $show_for , array(
+		$show_for = array_filter( shortcode_atts( array(
 			'capabilities' => array(),
 			'roles' => array(),
-		) );
+		), $show_for ) );
 
 		if ( empty( $show_for ) ) {
 			return $this;


### PR DESCRIPTION
This is needed, when we are allowing access for custom user roles to the administration interface.

Custom User Roles may be asked to fill in user details, like address, city, state etc. This change will allow the container to be visible for them.

The method `show_for` accepts an array, containing either or both `roles` and `capabilities`, which will be limiting the container visibility with logical `AND`, so when passing both, both will need to be evaluated to `true`.