### PR TITLE
Fix php error with association when term deleted

### DIFF
--- a/core/Field/Association_Field.php
+++ b/core/Field/Association_Field.php
@@ -110,7 +110,9 @@ class Association_Field extends Relationship_Field {
 			$title = get_the_title( $id );
 		} elseif ( $type === 'term' ) {
 			$term = get_term_by( 'id', $id, $subtype );
-			$title = $term->name;
+			if ( $term ) {
+				$title = $term->name;
+			}
 		} elseif ( $type === 'user' ) {
 			$title = get_the_author_meta( 'user_login', $id );
 		} elseif ( $type === 'comment' ) {


### PR DESCRIPTION
This occurs when a specific term is selected from the Association, and later the term is deleted from administration.

PHP error text:

```
var carbon_json = string(187) "Notice: Trying to get property of non-object in .../vendor/htmlburger/carbon-fields/core/Field/Association_Field.php on line 113"
```

Field Definition:

```
Field::make( 'association', 'categories', __('Categories', 'crb') )
	->set_types( array(
		array(
			'type' => 'term',
			'taxonomy' => 'category',
		)
	) )
```