### PR TITLE
Fix sidebar field incorrect value stored in DB

### DIFF
--- a/assets/js/fields.js
+++ b/assets/js/fields.js
@@ -966,7 +966,7 @@ window.carbon = window.carbon || {};
 				var sidebarId   = model.get('id');
 				var sidebar = {
 					name: sidebarName,
-					value: sidebarName
+					value: sidebarId
 				};
 
 				// If this sidebar is excluded ( by name or by ID), do not add it to the options.


### PR DESCRIPTION
This fixes the sidebar name being stored in database, rather than the sidebar ID.