### PR TITLE
Filter the capability needed to access theme options container

### DIFF
--- a/core/Container/Theme_Options_Container.php
+++ b/core/Container/Theme_Options_Container.php
@@ -41,7 +41,7 @@ class Theme_Options_Container extends Container {
 		}
 
 		if ( apply_filters( 'carbon_fields_' . $type . '_container_admin_only_access', true, $title ) ) {
-			$this->where( 'current_user_capability', '=', 'manage_options' );
+			$this->where( 'current_user_capability', '=', apply_filters( 'carbon_fields_' . $type . '_container_access_capability', 'manage_options', $title ) );
 		}
 	}
 


### PR DESCRIPTION
Allows for filtering of the default capability that is required for accessing the theme options container.

This is useful when wanting to allow access for management to specific users who are not the admin.