### PR TITLE
More defensive check for thumbnail url.

### DIFF
--- a/assets/js/fields/helpers.js
+++ b/assets/js/fields/helpers.js
@@ -19,11 +19,15 @@ import { TYPE_COMPLEX, PARENT_TYPE_GROUP, PARENT_TYPE_CONTAINER } from 'fields/c
  * @return {String}
  */
 export function getAttachmentThumbnail(attachment) {
+	thumbUrl = '';
 	if (attachment.sizes) {
-		return (attachment.sizes.thumbnail || attachment.sizes.full).url;
+		var size = attachment.sizes.thumbnail || attachment.sizes.full;
+		if (typeof(size) !== 'undefined') {
+			thumbUrl = size.url;
+		}
 	}
 
-	return '';
+	return thumbUrl;
 }
 
 /**


### PR DESCRIPTION
Some plugins may add new image type support (eg for svg) with non-standard size names. In that case this code will crash and the attachment will not be saved. This change resolves that.

The plugin causing the hiccup is using non-standard WP naming's, so I'll do a pull request for them too, but it seems desirable for the thumbnail preview to fail in these rare cases, rather than the attachment fail completely.