### PR TITLE
Rollback to "precise"-based test images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: precise
+
 language: php
 
 sudo: false


### PR DESCRIPTION
5.3 is no longer available on trusty, which is the default.

https://github.com/travis-ci/travis-ci/issues/2963