### PR TITLE
$_SERVER['REQUEST_METHOD']

### DIFF
--- a/core/Helper/Helper.php
+++ b/core/Helper/Helper.php
@@ -539,7 +539,7 @@ class Helper {
 	 * @return array
 	 */
 	public static function input() {
-		$input = $_SERVER['REQUEST_METHOD'] === 'POST' ? $_POST : $_GET;
+		$input = isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST' ? $_POST : $_GET;
 		$input = stripslashes_deep( $input );
 
 		if ( \Carbon_Fields\COMPACT_INPUT ) {


### PR DESCRIPTION
`$_SERVER` variables might not always be set (e.g. CLI). Wrapping this condition in `isset()` can eliminate a WP Debug notice.