### PR TITLE
Temporarily disable hash syncing for tabbed containers

### DIFF
--- a/assets/js/containers/components/network/index.js
+++ b/assets/js/containers/components/network/index.js
@@ -15,6 +15,6 @@ export default compose(
 	setStatic('type', TYPE_NETWORK),
 	withStore(),
 	withSetup({}, {
-		tabs_in_url: true
+		tabs_in_url: false
 	})
 )(Container);

--- a/assets/js/containers/components/theme-options/index.js
+++ b/assets/js/containers/components/theme-options/index.js
@@ -15,6 +15,6 @@ export default compose(
 	setStatic('type', TYPE_THEME_OPTIONS),
 	withStore(),
 	withSetup({}, {
-		tabs_in_url: true
+		tabs_in_url: false
 	})
 )(Container);


### PR DESCRIPTION
IE11 has a breaking bug that causes an infinite redirect.

IE bug ticket: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/3740423/