### PR TITLE
Maps improvement: Autocomplete & search field update

### DIFF
--- a/assets/css/modules/_fields.map.css
+++ b/assets/css/modules/_fields.map.css
@@ -10,33 +10,12 @@
 
 .carbon-map-search-button { position: absolute; left: 8px; top: 50%; margin-top: -10px; font-size: 0; color: $color-grey-font; background: none; border: none; box-shadow: none; cursor: pointer; }
 
-.carbon-map-search-autocomplete {
-  position: relative;
-}
+.carbon-map-search-autocomplete { position: relative; }
 
-.carbon-map-search-autocomplete--results {
-  box-shadow: 5px 5px 5px rgba(0, 0, 0, .3);
-  position:absolute;
-  left: 1em;
-  right: 1em;
-  top: 0;
-  z-index: 999;
-  background: #fff;
-}
+.carbon-map-search-autocomplete--results { box-shadow: 5px 5px 5px rgba(0, 0, 0, .3); position:absolute; left: 1em; right: 1em; top: 0; z-index: 999; background: #fff; }
 
-.carbon-map-search-autocomplete-search-field {}
+.carbon-map-search-autocomplete--loading { font-weight: 700; padding: 10px; text-align: center; }
 
-.carbon-map-search-autocomplete--loading {
-  font-weight: 700;
-  padding: 10px;
-  text-align: center;
-}
+.carbon-map-search-autocomplete--item { padding: 5px; cursor: pointer; }
 
-.carbon-map-search-autocomplete--item {
-  padding: 5px;
-  cursor: pointer;
-}
-
-.carbon-map-search-autocomplete--item.is-active {
-  background: #b2ebf2;
-}
+.carbon-map-search-autocomplete--item.is-active { background: #b2ebf2; }

--- a/assets/css/modules/_fields.map.css
+++ b/assets/css/modules/_fields.map.css
@@ -9,3 +9,34 @@
 .carbon-map-search-address { vertical-align: top; height:40px; margin: 0; padding: 10px 9px 10px 32px!important; font-size: 13px; }
 
 .carbon-map-search-button { position: absolute; left: 8px; top: 50%; margin-top: -10px; font-size: 0; color: $color-grey-font; background: none; border: none; box-shadow: none; cursor: pointer; }
+
+.carbon-map-search-autocomplete {
+  position: relative;
+}
+
+.carbon-map-search-autocomplete--results {
+  box-shadow: 5px 5px 5px rgba(0, 0, 0, .3);
+  position:absolute;
+  left: 1em;
+  right: 1em;
+  top: 0;
+  z-index: 999;
+  background: #fff;
+}
+
+.carbon-map-search-autocomplete-search-field {}
+
+.carbon-map-search-autocomplete--loading {
+  font-weight: 700;
+  padding: 10px;
+  text-align: center;
+}
+
+.carbon-map-search-autocomplete--item {
+  padding: 5px;
+  cursor: pointer;
+}
+
+.carbon-map-search-autocomplete--item.is-active {
+  background: #b2ebf2;
+}

--- a/assets/js/fields/components/map/google-map.js
+++ b/assets/js/fields/components/map/google-map.js
@@ -103,6 +103,7 @@ class GoogleMap extends React.Component {
 	 * @return {void}
 	 */
 	setupMapEvents() {
+
 		// Enable the zoom with scrollwheel when the user interacts with the map.
 		const enableScrollZoom = () => {
 			this.map.setOptions({
@@ -125,12 +126,31 @@ class GoogleMap extends React.Component {
 
 		google.maps.event.addListener(this.map, 'zoom_changed', handleZoomChange);
 
+
+	  const convertLatLngToAddress = (lat, lng) => {
+			let latlng = new google.maps.LatLng(lat, lng);
+		  let geocoder = new google.maps.Geocoder();
+
+			geocoder.geocode({ 'latLng': latlng }, (results, status) => {
+				if (status === google.maps.GeocoderStatus.OK && results[1]) {
+					this.props.onChange({
+						address: results[1].formatted_address
+					});
+				} else {
+					console.warn('Geocoder failed: ', status, results);
+				}
+			});
+	  }
+
 		// Update the position when the marker is moved.
 		const handleDragEnd = () => {
 			this.props.onChange({
 				lat: this.marker.getPosition().lat(),
 				lng: this.marker.getPosition().lng(),
+				address: ''
 			});
+
+			convertLatLngToAddress(this.marker.getPosition().lat(), this.marker.getPosition().lng());
 		};
 
 		google.maps.event.addListener(this.marker, 'dragend', handleDragEnd);
@@ -163,6 +183,7 @@ GoogleMap.propTypes = {
 	lat: PropTypes.number,
 	lng: PropTypes.number,
 	zoom: PropTypes.number,
+	address: PropTypes.string,
 	onChange: PropTypes.func
 };
 

--- a/assets/js/fields/components/map/google-map.js
+++ b/assets/js/fields/components/map/google-map.js
@@ -147,7 +147,6 @@ class GoogleMap extends React.Component {
 			this.props.onChange({
 				lat: this.marker.getPosition().lat(),
 				lng: this.marker.getPosition().lng(),
-				address: ''
 			});
 
 			convertLatLngToAddress(this.marker.getPosition().lat(), this.marker.getPosition().lng());

--- a/assets/js/fields/components/map/google-map.js
+++ b/assets/js/fields/components/map/google-map.js
@@ -134,7 +134,7 @@ class GoogleMap extends React.Component {
 			geocoder.geocode({ 'latLng': latlng }, (results, status) => {
 				if (status === google.maps.GeocoderStatus.OK && results[1]) {
 					this.props.onChange({
-						address: results[1].formatted_address
+						address: results[this.props.search_detail_level].formatted_address
 					});
 				} else {
 					console.warn('Geocoder failed: ', status, results);
@@ -180,6 +180,7 @@ class GoogleMap extends React.Component {
  */
 GoogleMap.propTypes = {
 	className: PropTypes.string,
+	search_detail_level: PropTypes.number,
 	lat: PropTypes.number,
 	lng: PropTypes.number,
 	zoom: PropTypes.number,

--- a/assets/js/fields/components/map/index.js
+++ b/assets/js/fields/components/map/index.js
@@ -68,6 +68,7 @@ const MapField = ({
 			className="carbon-map-canvas"
 			lat={field.value.lat}
 			lng={field.value.lng}
+			address={field.value.address}
 			zoom={field.value.zoom}
 			onChange={handleChange} />
 	</Field>;

--- a/assets/js/fields/components/map/index.js
+++ b/assets/js/fields/components/map/index.js
@@ -101,6 +101,7 @@ const MapField = ({
 			lat={field.value.lat}
 			lng={field.value.lng}
 			address={field.value.address}
+			search_detail_level={field.search_detail_level}
 			zoom={field.value.zoom}
 			onChange={handleChange} />
 	</Field>;

--- a/core/Field/Map_Field.php
+++ b/core/Field/Map_Field.php
@@ -3,6 +3,7 @@
 namespace Carbon_Fields\Field;
 
 use Carbon_Fields\Value_Set\Value_Set;
+use Carbon_Fields\Exception\Incorrect_Syntax_Exception;
 
 /**
  * Google Maps with Address field class.
@@ -26,6 +27,13 @@ class Map_Field extends Field {
 	 * {@inheritDoc}
 	 */
 	protected $lazyload = true;
+
+	/**
+	 * Search Field detail level
+	 *
+	 * @var        integer
+	 */
+	protected $search_detail_level = 0;
 
 	/**
 	 * Create a field from a certain type with the specified label.
@@ -102,6 +110,7 @@ class Map_Field extends Field {
 
 		$value_set = $this->get_value();
 		$field_data = array_merge( $field_data, array(
+			'search_detail_level' => $this->search_detail_level,
 			'value' => array(
 				'lat' => floatval( $value_set['lat'] ),
 				'lng' => floatval( $value_set['lng'] ),
@@ -132,5 +141,27 @@ class Map_Field extends Field {
 				'zoom' => $zoom,
 			)
 		) );
+	}
+
+
+	/**
+	 * Set the level of detail recveived from address search field.
+	 * Level can be anything between 0 and 5:
+	 * - 0 being the most detailed (full address)
+	 * - 5 being the most generic (i.e. country)
+	 *
+	 * @param      integer  $level
+	 * @return self   $this
+	 */
+	public function search_detail_level( $level )
+	{
+		if ($level > 5 || $level < 0) {
+			Incorrect_Syntax_Exception::raise( 'Map level out of range! Accepted: 0 - 5. Provided: ' . $level );
+			return $this;
+		}
+
+		$this->search_detail_level = (int) $level;
+
+		return $this;
 	}
 }

--- a/core/Field/Map_Field.php
+++ b/core/Field/Map_Field.php
@@ -45,7 +45,7 @@ class Map_Field extends Field {
 	 */
 	public static function admin_enqueue_scripts() {
 		$api_key = apply_filters( 'carbon_fields_map_field_api_key', false );
-		$url = apply_filters( 'carbon_fields_map_field_api_url', '//maps.googleapis.com/maps/api/js?' . ( $api_key ? 'key=' . $api_key : '' ), $api_key );
+		$url = apply_filters( 'carbon_fields_map_field_api_url', '//maps.googleapis.com/maps/api/js?libraries=places&' . ( $api_key ? 'key=' . $api_key : '' ), $api_key );
 
 		wp_enqueue_script( 'carbon-google-maps', $url, array(), null );
 	}

--- a/core/Field/Map_Field.php
+++ b/core/Field/Map_Field.php
@@ -153,9 +153,8 @@ class Map_Field extends Field {
 	 * @param      integer  $level
 	 * @return self   $this
 	 */
-	public function search_detail_level( $level )
-	{
-		if ($level > 5 || $level < 0) {
+	public function search_detail_level( $level ) {
+		if ( $level > 5 || $level < 0 ) {
 			Incorrect_Syntax_Exception::raise( 'Map level out of range! Accepted: 0 - 5. Provided: ' . $level );
 			return $this;
 		}

--- a/core/Loader/Loader.php
+++ b/core/Loader/Loader.php
@@ -168,6 +168,7 @@ class Loader {
 				'setShowAll' => __( 'Show all options', 'carbon-fields' ),
 
 				'searchPlaceholder' => __( 'Search...', 'carbon-fields' ),
+				'loading' => __( 'Loading', 'carbon-fields' ),
 
 				'editAttachmentUrl' => _x( 'URL', 'WordPress media attachment', 'carbon-fields' ),
 				'editAttachmentTitle' => _x( 'Title', 'WordPress media attachment', 'carbon-fields' ),

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-dom": "^16",
     "react-flatpickr": "^3.6.4",
     "react-onclickoutside": "^5.11.1",
+    "react-places-autocomplete": "^7.2.0",
     "react-redux": "^5.0.4",
     "react-select": "^1.0.0-rc.10",
     "recompose": "^0.23.1",


### PR DESCRIPTION
Map field always felt a bit crippled: search field didn't really provide any feedback, moving pointer didn't provide any feedback either, selecting an exact point was feeling like an adventure.

So here we are, with some improvements:

1. Searching anything will also provide a nice autocomplete (by using [react places autocomplete](https://www.npmjs.com/package/react-places-autocomplete))
1. Moving pointer will update the search box
1. When configuring the field, you can make use of `->search_detail_level( 1 )` method in order to tweak the details provided by the search box (0 being the most detailed, 5 the most generic).

![ezgif com-gif-maker](https://user-images.githubusercontent.com/132062/42392871-0184927e-815d-11e8-8e56-5c7b8dd0430d.gif)

---

Obviously, this requires the right Google API permission (for places & geocoding).

---

This will close #423

I'm fairly new at the React game, so if I anything is not done „the react way”, please let me know :)


