### PR TITLE
Fixing Association field issue when embeded in Complex field

### DIFF
--- a/packages/metaboxes/fields/association/index.js
+++ b/packages/metaboxes/fields/association/index.js
@@ -24,7 +24,7 @@ import stripCompactInputPrefix from '../../utils/strip-compact-input-prefix';
  */
 function findFieldByName( fields, name ) {
 	return find( fields, ( field ) => {
-		return field.name.indexOf( name ) === 0;
+		return field.name === name;
 	} );
 }
 


### PR DESCRIPTION
The findFieldByName function was returning the wrong field if the
Complex field name's was the starting string of the Association name.

Ex:
Complex field name: post_people
Association field name: post_people_assoc
More details here:
https://github.com/htmlburger/carbon-fields/issues/636