### PR TITLE
Fix complex field inserter z-index

### DIFF
--- a/packages/core/fields/complex/style.scss
+++ b/packages/core/fields/complex/style.scss
@@ -181,6 +181,7 @@
 	min-width: 180px;
 	margin: 0;
 	transform: translate(10px, -50%);
+	z-index: 1;
 }
 
 .cf-complex__inserter-item {


### PR DESCRIPTION
The complex field inserter menu does not have a z-index meaning that the 'Thank you for creating with WordPress' Banner shows over the menu, making the last item unselectable.