### PR TITLE
Fix issue where alpha part was not saved in Color fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-flatpickr": "^3.6.4",
     "react-onclickoutside": "^6.7.1",
     "react-select": "^2.1.1",
-    "refract-callbag": "^4.0.0"
+    "refract-callbag": "^4.0.0",
+    "tinycolor2": "^1.4.1"
   }
 }

--- a/packages/core/fields/color/index.js
+++ b/packages/core/fields/color/index.js
@@ -4,13 +4,13 @@
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { get } from 'lodash';
+import tinycolor from 'tinycolor2';
 
 /**
  * Internal dependencies.
  */
 import './style.scss';
 import Picker from './picker';
-import hexToRgba from '../../utils/hex-to-rgba';
 
 class ColorField extends Component {
 	/**
@@ -28,13 +28,9 @@ class ColorField extends Component {
 	 * @return {void}
 	 */
 	getBackgrounColor = () => {
-		const { field, value } = this.props;
+		const colorHex = this.props.value || '#FFFFFFFF';
 
-		const colorHex = value ? value : '#FFFFFFFF';
-		const [ r, g, b, a ] = hexToRgba( colorHex );
-		const rgbaColor = { r, g, b, a: field.alphaEnabled ? a : 1 };
-
-		return `rgba(${ Object.values( rgbaColor ).join( ', ' ) })`;
+		return tinycolor( colorHex ).toRgbString();
 	}
 
 	/**
@@ -45,15 +41,10 @@ class ColorField extends Component {
 	 */
 	handleChange = ( color ) => {
 		const { id, field, onChange } = this.props;
-		const colorHex = get( color, 'hex', '' );
+		const rgb = get( color, 'rgb', '' );
+		const format = field.alphaEnabled ? 'hex8' : 'hex6';
 
-		if ( colorHex && field.alphaEnabled ) {
-			const alpha = get( color, 'rgb.a', 1 );
-			const alphaHex = Math.round( parseFloat( alpha ) * 255 ).toString( 16 ).padStart( 2, '0' );
-			onChange( id, colorHex + alphaHex );
-		} else {
-			onChange( id, colorHex );
-		}
+		onChange( id, rgb ? tinycolor( rgb ).toString( format ) : '' );
 	}
 
 	/**

--- a/packages/core/fields/color/index.js
+++ b/packages/core/fields/color/index.js
@@ -44,9 +44,16 @@ class ColorField extends Component {
 	 * @return {void}
 	 */
 	handleChange = ( color ) => {
-		const { id, onChange } = this.props;
+		const { id, field, onChange } = this.props;
+		const colorHex = get( color, 'hex', '' );
 
-		onChange( id, get( color, 'hex', '' ) );
+		if ( colorHex && field.alphaEnabled ) {
+			const alpha = get( color, 'rgb.a', 1 );
+			const alphaHex = Math.round( parseFloat( alpha ) * 255 ).toString( 16 ).padStart( 2, '0' );
+			onChange( id, colorHex + alphaHex );
+		} else {
+			onChange( id, colorHex );
+		}
 	}
 
 	/**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7088,6 +7088,7 @@ tiny-emitter@^2.0.0:
 tinycolor2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
+  integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
 tinymce@^4.7.2:
   version "4.9.0"


### PR DESCRIPTION
It seems that SketchPicker doesn't include the alpha part in the hex string. I added code to extract the alpha from `rgb.a`, convert it to hex string and append to the result.

Fixes #648 