### PR TITLE
Expose the Container and registerContainerType in JS

### DIFF
--- a/bin/webpack.metaboxes.js
+++ b/bin/webpack.metaboxes.js
@@ -15,6 +15,10 @@ const config = {
 	entry: {
 		metaboxes: './packages/metaboxes/index.js'
 	},
+	output: {
+		library: [ 'cf', '[name]' ],
+		libraryTarget: 'this'
+	},
 	externals: {
 		'react': [ 'cf', 'vendor', 'react' ],
 		'react-dom': [ 'cf', 'vendor', 'react-dom' ],

--- a/packages/metaboxes/containers/index.js
+++ b/packages/metaboxes/containers/index.js
@@ -17,6 +17,8 @@ import './user-meta';
 import Container from '../components/container';
 import { getContainerType, registerContainerType } from './registry';
 
+export { registerContainerType, Container };
+
 /**
  * Registers the containers.
  */

--- a/packages/metaboxes/index.js
+++ b/packages/metaboxes/index.js
@@ -10,8 +10,14 @@ import { addAction } from '@wordpress/hooks';
 import './store';
 import './fields';
 import initializeMonitors from './monitors';
-import initializeContainers from './containers';
+import { default as initializeContainers, registerContainerType, Container } from './containers';
+
 import isGutenberg from './utils/is-gutenberg';
+
+/**
+ * Public API
+ */
+export { registerContainerType, Container };
 
 /**
  * Sets the locale data for the package type


### PR DESCRIPTION
Expose the container component and registerContainerType function so we can extend the container outside of the plugin.