### PR TITLE
Add support for taxonomy-filtered association fields (not part of the main repo)

### DIFF
--- a/core/REST_API/Router.php
+++ b/core/REST_API/Router.php
@@ -302,15 +302,20 @@ class Router {
 		$options = array_map( function ( $option ) {
 			$option = explode( ':', $option );
 
-			return [
+			$res = [
 				'id'      => $option[0],
 				'type'    => $option[1],
 				'subtype' => $option[2],
 			];
+			if ( ! empty( $option[3] ) ) {
+				$res['taxTerm'] = intval( $option[3] );
+			}
+			return $res;
 		}, $options );
 
 		foreach ( $options as $option ) {
 			$item = array(
+				'taxTerm'    => ! empty( $option['taxTerm'] ) ? $option['taxTerm'] : 0,
 				'type'       => $option['type'],
 				'subtype'    => $option['subtype'],
 				'thumbnail'  => $field->get_thumbnail_by_type( $option['id'], $option['type'], $option['subtype'] ),

--- a/languages/carbon-fields-ui.pot
+++ b/languages/carbon-fields-ui.pot
@@ -3,20 +3,28 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-makepot\n"
 
-#: packages/blocks/components/block-edit/index.js:201
+#: packages/blocks/components/block-edit/index.js:214
 msgid "Show preview"
 msgstr ""
 
-#: packages/blocks/components/block-edit/index.js:202
+#: packages/blocks/components/block-edit/index.js:215
 msgid "Hide preview"
 msgstr ""
 
-#: packages/blocks/components/block-edit/index.js:271
+#: packages/blocks/components/block-edit/index.js:286
 msgid "Fields"
 msgstr ""
 
 #: packages/blocks/components/not-supported-field/index.js:14
 msgid "Field of type '%s' is not supported in Gutenberg."
+msgstr ""
+
+#: packages/blocks/components/server-side-render/index.js:129
+msgid "Error loading block: %s"
+msgstr ""
+
+#: packages/blocks/components/server-side-render/index.js:135
+msgid "No results found."
 msgstr ""
 
 #: packages/blocks/fields/datetime/index.js:59
@@ -63,29 +71,29 @@ msgstr ""
 msgid "Search..."
 msgstr ""
 
-#: packages/core/fields/association/index.js:113
+#: packages/core/fields/association/index.js:168
 msgid "Maximum number of items reached (%s items)"
 msgstr ""
 
-#: packages/core/fields/association/index.js:204
+#: packages/core/fields/association/index.js:266
 msgid "Showing %1$d of %2$d results"
 msgstr ""
 
-#: packages/core/fields/association/index.js:380
+#: packages/core/fields/association/index.js:449
 msgid "An error occurred while trying to fetch association options."
 msgstr ""
 
-#: packages/core/fields/association/index.js:430
+#: packages/core/fields/association/index.js:506
 #: packages/core/fields/complex/index.js:428
 #: packages/core/hocs/with-validation/required.js:20
 msgid "This field is required."
 msgstr ""
 
-#: packages/core/fields/association/index.js:434
+#: packages/core/fields/association/index.js:510
 msgid "Minimum number of items not reached (%s items)"
 msgstr ""
 
-#: packages/core/fields/color/index.js:86
+#: packages/core/fields/color/index.js:92
 msgid "Select a color"
 msgstr ""
 
@@ -197,7 +205,7 @@ msgstr ""
 msgid "An error occurred while trying to fetch files data."
 msgstr ""
 
-#: packages/metaboxes/containers/index.js:52
+#: packages/metaboxes/containers/index.js:55
 msgid "Could not find DOM element for container \"%1$s\"."
 msgstr ""
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -21,12 +21,15 @@ setLocaleData( window.cf.config.locale, 'carbon-fields-ui' );
 export { createRegistry } from './registry';
 export { getFieldType, registerFieldType } from './registry/fields';
 export { default as Field } from './components/field';
+export { default as SearchInput } from './components/search-input';
+export { default as Sortable } from './components/sortable';
 export { default as withFilters } from './hocs/with-filters';
 export { default as withProps } from './hocs/with-props';
 export { default as withValidation } from './hocs/with-validation';
 export { default as withConditionalLogic } from './hocs/with-conditional-logic';
 export { default as uniqueId } from './utils/unique-id';
 export { default as fromSelector } from './utils/from-selector';
+export { default as apiFetch } from './utils/api-fetch';
 
 /**
  * Triggers the initialization of Carbon Fields.

--- a/packages/metaboxes/index.js
+++ b/packages/metaboxes/index.js
@@ -17,6 +17,7 @@ import isGutenberg from './utils/is-gutenberg';
  * Public API.
  */
 export { registerContainerType, getContainerType } from './containers/registry';
+export { default as stripCompactInputPrefix } from './utils/strip-compact-input-prefix';
 
 /**
  * Sets the locale data for the package type


### PR DESCRIPTION
 * add taxonomy term argument to association field request
 * export some unexposed dependencies, needed for a custom field