### PR TITLE
Static Analysis Fixes

### DIFF
--- a/.phpstorm.meta.php/ioc.meta.php
+++ b/.phpstorm.meta.php/ioc.meta.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @see https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata#PhpStormAdvancedMetadata-Factorymethods
+ */
+
+namespace PHPSTORM_META {
+
+	// Carbon_Fields::resolve()
+	override(
+		\Carbon_Fields\Carbon_Fields::resolve( 0 ),
+		map(
+			[
+				'container_condition_fulfillable_collection' => \Carbon_Fields\Container\Fulfillable\Fulfillable_Collection::class,
+				'container_condition_translator_json' => \Carbon_Fields\Container\Fulfillable\Translator\Json_Translator::class,
+				'container_repository' => \Carbon_Fields\Container\Repository::class,
+				'containers' => \Carbon_Fields\Pimple\Container::class,
+				'fields' => \Carbon_Fields\Pimple\Container::class,
+				'key_toolset' => \Carbon_Fields\Toolset\Key_Toolset::class,
+				'loader' => \Carbon_Fields\Loader\Loader::class,
+				'rest_api_decorator' => \Carbon_Fields\REST_API\Decorator::class,
+				'rest_api_router' => \Carbon_Fields\REST_API\Router::class,
+				'sidebar_manager' => \Carbon_Fields\Libraries\Sidebar_Manager\Sidebar_Manager::class,
+				'wp_toolset' => \Carbon_Fields\Toolset\WP_Toolset::class,
+				/* Events */
+				'event_emitter' => \Carbon_Fields\Event\Emitter::class,
+				'event_persistent_listener' => \Carbon_Fields\Event\PersistentListener::class,
+				'event_single_event_listener' => \Carbon_Fields\Event\SingleEventListener::class,
+			]
+		)
+	);
+
+	// Carbon_Fields::service()
+	override(
+		\Carbon_Fields\Carbon_Fields::service( 0 ),
+		map(
+			[
+				/* Services */
+				'legacy_storage' => \Carbon_Fields\Service\Legacy_Storage_Service_v_1_5::class,
+				'meta_query' => \Carbon_Fields\Service\Meta_Query_Service::class,
+				'rest_api' => \Carbon_Fields\Service\REST_API_Service::class,
+				'revisions' => \Carbon_Fields\Service\Revisions_Service::class,
+			]
+		)
+	);
+
+
+	// Pimple
+	override(
+		new \Carbon_Fields\Pimple\Container,
+		map(
+			[
+				'container_conditions' => \Carbon_Fields\Pimple\Container::class,
+			]
+		)
+	);
+
+}

--- a/core/Carbon_Fields.php
+++ b/core/Carbon_Fields.php
@@ -210,8 +210,6 @@ final class Carbon_Fields {
 
 	/**
 	 * Throw exception if fields have not been registered yet
-	 *
-	 * @throws Incorrect_Syntax_Exception
 	 */
 	public static function verify_fields_registered() {
 		$register_action = 'carbon_fields_register_fields';

--- a/core/Carbon_Fields.php
+++ b/core/Carbon_Fields.php
@@ -52,7 +52,7 @@ final class Carbon_Fields {
 	/**
 	 * Singleton implementation
 	 *
-	 * @return Carbon_Fields\Carbon_Fields
+	 * @return Carbon_Fields
 	 */
 	public static function instance() {
 		static $instance = null;
@@ -210,6 +210,8 @@ final class Carbon_Fields {
 
 	/**
 	 * Throw exception if fields have not been registered yet
+	 *
+	 * @throws Incorrect_Syntax_Exception
 	 */
 	public static function verify_fields_registered() {
 		$register_action = 'carbon_fields_register_fields';
@@ -266,7 +268,8 @@ final class Carbon_Fields {
 	 * Add a listener to an event
 	 *
 	 * @param string   $event
-	 * @return Listener $listener
+	 * @param Event\Listener $listener
+	 * @return Event\Listener $listener
 	 */
 	public static function add_listener( $event, $listener ) {
 		return static::instance()->get_emitter()->add_listener( $event, $listener );
@@ -275,7 +278,7 @@ final class Carbon_Fields {
 	/**
 	 * Remove a listener from any event
 	 *
-	 * @param Listener $listener
+	 * @param Event\Listener $listener
 	 */
 	public static function remove_listener( $listener ) {
 		static::instance()->get_emitter()->remove_listener( $listener );
@@ -286,7 +289,7 @@ final class Carbon_Fields {
 	 *
 	 * @param  string   $event    The event to listen for
 	 * @param  string   $callable The callable to call when the event is broadcasted
-	 * @return Listener
+	 * @return Event\Listener
 	 */
 	public static function on( $event, $callable ) {
 		return static::instance()->get_emitter()->on( $event, $callable );
@@ -297,7 +300,7 @@ final class Carbon_Fields {
 	 *
 	 * @param  string   $event    The event to listen for
 	 * @param  string   $callable The callable to call when the event is broadcasted
-	 * @return Listener
+	 * @return Event\Listener
 	 */
 	public static function once( $event, $callable ) {
 		return static::instance()->get_emitter()->once( $event, $callable );
@@ -354,7 +357,7 @@ final class Carbon_Fields {
 
 		$ioc['services']['revisions'] = function() use ( $ioc ) {
 			return new Revisions_Service();
-		};		
+		};
 
 		$ioc['services']['meta_query'] = function() use ( $ioc ) {
 			return new Meta_Query_Service( $ioc['container_repository'], $ioc['key_toolset'] );

--- a/core/Container.php
+++ b/core/Container.php
@@ -5,6 +5,14 @@ namespace Carbon_Fields;
 /**
  * Container proxy factory class.
  * Used for shorter namespace access when creating a container.
+ *
+ * @method static \Carbon_Fields\Container\Comment_Meta_Container make_comment_meta( string $id, string $name = null )
+ * @method static \Carbon_Fields\Container\Nav_Menu_Item_Container make_nav_menu_item( string $id, string $name = null )
+ * @method static \Carbon_Fields\Container\Network_Container make_network( string $id, string $name = null )
+ * @method static \Carbon_Fields\Container\Post_Meta_Container make_post_meta( string $id, string $name = null )
+ * @method static \Carbon_Fields\Container\Term_Meta_Container make_term_meta( string $id, string $name = null )
+ * @method static \Carbon_Fields\Container\Theme_Options_Container make_theme_options( string $id, string $name = null )
+ * @method static \Carbon_Fields\Container\User_Meta_Container make_user_meta( string $id, string $name = null )
  */
 class Container {
 
@@ -26,5 +34,21 @@ class Container {
 	 */
 	public static function make() {
 		return call_user_func_array( array( get_class(), 'factory' ), func_get_args() );
+	}
+
+	/**
+	 * @param string $method
+	 * @param array $arguments
+	 *
+	 * @return mixed
+	 */
+	public static function __callStatic( $method, $arguments ) {
+		if ( strpos( $method, 'make_' ) === 0 ) {
+			$raw_type = substr_replace( $method, '', 0, 5 );
+			array_unshift( $arguments, $raw_type );
+			return call_user_func_array( array( get_class(), 'factory' ), $arguments );
+		} else {
+			trigger_error( sprintf( 'Call to undefined function: %s::%s().', get_class(), $method ), E_USER_ERROR );
+		}
 	}
 }

--- a/core/Container/Condition/Condition.php
+++ b/core/Container/Condition/Condition.php
@@ -20,7 +20,7 @@ abstract class Condition implements Fulfillable {
 	/**
 	 * Comparers to use for condition checking
 	 *
-	 * @var array<Comparer>
+	 * @var \Carbon_Fields\Container\Condition\Comparer\Comparer[]
 	 */
 	protected $comparers = array();
 
@@ -57,7 +57,7 @@ abstract class Condition implements Fulfillable {
 	/**
 	 * Get the condition comparers
 	 *
-	 * @return array<Comparer>
+	 * @return \Carbon_Fields\Container\Condition\Comparer\Comparer[]
 	 */
 	protected function get_comparers() {
 		return $this->comparers;
@@ -66,7 +66,7 @@ abstract class Condition implements Fulfillable {
 	/**
 	 * Set the condition comparers
 	 *
-	 * @param array<Comparer> $comparers
+	 * @param \Carbon_Fields\Container\Condition\Comparer\Comparer[] $comparers
 	 * @return Condition $this
 	 */
 	public function set_comparers( $comparers ) {
@@ -108,7 +108,7 @@ abstract class Condition implements Fulfillable {
 	 * Set comparison sign
 	 *
 	 * @param string $comparison_operator
-	 * @return Comparer $this
+	 * @return $this
 	 */
 	public function set_comparison_operator( $comparison_operator ) {
 		$this->comparison_operator = $comparison_operator;

--- a/core/Container/Condition/Factory.php
+++ b/core/Container/Condition/Factory.php
@@ -14,6 +14,8 @@ class Factory {
 
 	/**
 	 * Constructor
+	 *
+	 * @param \Carbon_Fields\Pimple\Container $ioc
 	 */
 	public function __construct( $ioc ) {
 		$this->ioc = $ioc;

--- a/core/Container/Container.php
+++ b/core/Container/Container.php
@@ -64,11 +64,25 @@ abstract class Container implements Datastore_Holder_Interface {
 	public $settings = array();
 
 	/**
+	 * Unique ID of the container
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
 	 * Title of the container
 	 *
 	 * @var string
 	 */
 	public $title = '';
+
+	/**
+	 * Type of the container
+	 *
+	 * @var string
+	 */
+	public $type;
 
 	/**
 	 * List of notification messages to be displayed on the front-end
@@ -106,7 +120,7 @@ abstract class Container implements Datastore_Holder_Interface {
 	 *
 	 * @see set_datastore()
 	 * @see get_datastore()
-	 * @var object
+	 * @var Datastore_Interface
 	 */
 	protected $datastore;
 
@@ -129,7 +143,7 @@ abstract class Container implements Datastore_Holder_Interface {
 	/**
 	 * Translator to use when translating conditions to json
 	 *
-	 * @var Carbon_Fields\Container\Fulfillable\Translator\Translator
+	 * @var \Carbon_Fields\Container\Fulfillable\Translator\Translator
 	 */
 	protected $condition_translator;
 
@@ -205,7 +219,7 @@ abstract class Container implements Datastore_Holder_Interface {
 	 * @param string                 $title                Title of the container
 	 * @param string                 $type                 Type of the container
 	 * @param Fulfillable_Collection $condition_collection
-	 * @param Carbon_Fields\Container\Fulfillable\Translator\Translator $condition_translator
+	 * @param \Carbon_Fields\Container\Fulfillable\Translator\Translator $condition_translator
 	 */
 	public function __construct( $id, $title, $type, $condition_collection, $condition_translator ) {
 		Carbon_Fields::verify_boot();
@@ -452,7 +466,7 @@ abstract class Container implements Datastore_Holder_Interface {
 	 * Returns the private container array of fields.
 	 * Use only if you are completely aware of what you are doing.
 	 *
-	 * @return \Carbon_Fields\Field\Field[]
+	 * @return Field[]
 	 */
 	public function get_fields() {
 		return $this->fields;
@@ -587,6 +601,7 @@ abstract class Container implements Datastore_Holder_Interface {
 	 * Set datastore instance
 	 *
 	 * @param Datastore_Interface $datastore
+	 * @param bool                $set_as_default (optional)
 	 * @return Container $this
 	 */
 	public function set_datastore( Datastore_Interface $datastore, $set_as_default = false ) {

--- a/core/Container/Container.php
+++ b/core/Container/Container.php
@@ -146,7 +146,7 @@ abstract class Container implements Datastore_Holder_Interface {
 		if ( $name === '' ) {
 			$name = $id;
 			$id = '';
-		}
+	}
 
 		$type = Helper::normalize_type( $raw_type );
 		$repository = Carbon_Fields::resolve( 'container_repository' );
@@ -452,7 +452,7 @@ abstract class Container implements Datastore_Holder_Interface {
 	 * Returns the private container array of fields.
 	 * Use only if you are completely aware of what you are doing.
 	 *
-	 * @return array
+	 * @return \Carbon_Fields\Field\Field[]
 	 */
 	public function get_fields() {
 		return $this->fields;
@@ -539,7 +539,7 @@ abstract class Container implements Datastore_Holder_Interface {
 					$field = clone $f;
 					$field->set_hierarchy_index( $hierarchy_index );
 				} else {
-					if ( ! is_a( $f, 'Carbon_Fields\\Field\\Complex_Field' ) ) {
+					if ( ! ( $f instanceof \Carbon_Fields\Field\Complex_Field ) ) {
 						return null;
 					}
 
@@ -805,7 +805,7 @@ abstract class Container implements Datastore_Holder_Interface {
 	 */
 	public function add_fields( $fields ) {
 		foreach ( $fields as $field ) {
-			if ( ! is_a( $field, 'Carbon_Fields\\Field\\Field' ) ) {
+			if ( ! ( $field instanceof Field ) ) {
 				Incorrect_Syntax_Exception::raise( 'Object must be of type Carbon_Fields\\Field\\Field' );
 				return $this;
 			}

--- a/core/Container/Fulfillable/Fulfillable_Collection.php
+++ b/core/Container/Fulfillable/Fulfillable_Collection.php
@@ -133,8 +133,8 @@ class Fulfillable_Collection implements Fulfillable {
 		$condition_type_list = $this->get_condition_type_list();
 		$fulfillables = $this->get_fulfillables();
 		foreach ( $fulfillables as $fulfillable ) {
-			if ( is_a( $fulfillable['fulfillable'], get_class() ) ) {
-				$fulfillable->set_condition_type_list( $condition_type_list, $this->is_condition_type_list_whitelist() );
+			if ( $fulfillable['fulfillable'] instanceof Fulfillable_Collection ) {
+				$fulfillable['fulfillable']->set_condition_type_list( $condition_type_list, $this->is_condition_type_list_whitelist() );
 			}
 		}
 	}
@@ -268,7 +268,7 @@ class Fulfillable_Collection implements Fulfillable {
 			$fulfillable = $fulfillable_tuple['fulfillable'];
 			$fulfillable_comparison = $fulfillable_tuple['fulfillable_comparison'];
 
-			if ( is_a( $fulfillable, get_class() ) ) {
+			if ( $fulfillable instanceof Fulfillable_Collection ) {
 				$filtered_collection = $fulfillable->filter( $condition_whitelist );
 				$filtered_collection_fulfillables = $filtered_collection->get_fulfillables();
 				if ( empty( $filtered_collection_fulfillables ) ) {
@@ -308,7 +308,7 @@ class Fulfillable_Collection implements Fulfillable {
 			$fulfillable = $fulfillable_tuple['fulfillable'];
 			$fulfillable_comparison = $fulfillable_tuple['fulfillable_comparison'];
 
-			if ( is_a( $fulfillable, get_class() ) ) {
+			if ( $fulfillable instanceof Fulfillable_Collection ) {
 				$evaluated_collection = $fulfillable->evaluate( $condition_types, $environment, $comparison_operators, $condition_types_blacklist, $comparison_operators_blacklist );
 				$collection->add_fulfillable( $evaluated_collection, $fulfillable_comparison );
 			} else {

--- a/core/Container/Fulfillable/Translator/Array_Translator.php
+++ b/core/Container/Fulfillable/Translator/Array_Translator.php
@@ -3,7 +3,6 @@
 namespace Carbon_Fields\Container\Fulfillable\Translator;
 
 use Carbon_Fields\Container\Condition\Factory;
-use Carbon_Fields\Container\Fulfillable\Fulfillable;
 use Carbon_Fields\Container\Fulfillable\Fulfillable_Collection;
 use Carbon_Fields\Container\Condition\Condition;
 use Carbon_Fields\Exception\Incorrect_Syntax_Exception;

--- a/core/Container/Fulfillable/Translator/Translator.php
+++ b/core/Container/Fulfillable/Translator/Translator.php
@@ -16,11 +16,11 @@ abstract class Translator {
 	 * @return mixed
 	 */
 	public function fulfillable_to_foreign( Fulfillable $fulfillable ) {
-		if ( is_a( $fulfillable, 'Carbon_Fields\\Container\\Condition\\Condition' ) ) {
+		if ( $fulfillable instanceof Condition ) {
 			return $this->condition_to_foreign( $fulfillable );
 		}
 
-		if ( is_a( $fulfillable, 'Carbon_Fields\\Container\\Fulfillable\\Fulfillable_Collection' ) ) {
+		if ( $fulfillable instanceof Fulfillable_Collection ) {
 			return $this->fulfillable_collection_to_foreign( $fulfillable );
 		}
 

--- a/core/Container/Repository.php
+++ b/core/Container/Repository.php
@@ -52,7 +52,7 @@ class Repository {
 	/**
 	 * Register a container with the repository
 	 *
-	 * @return array
+	 * @param Container $container
 	 */
 	public function register_container( Container $container ) {
 		$this->register_unique_container_id( $container->get_id() );
@@ -63,7 +63,7 @@ class Repository {
 	/**
 	 * Initialize registered containers
 	 *
-	 * @return array
+	 * @return Container[]
 	 */
 	public function initialize_containers() {
 		$initialized_containers = array();
@@ -79,7 +79,7 @@ class Repository {
 	 * Return all containers
 	 *
 	 * @param string $type Container type to filter for
-	 * @return array
+	 * @return Container[]
 	 */
 	public function get_containers( $type = null ) {
 		$raw_containers = $this->containers;
@@ -105,7 +105,7 @@ class Repository {
 	 * @param  string                    $field_name
 	 * @param  string                    $container_id
 	 * @param  bool                      $include_nested_fields
-	 * @return Carbon_Fields\Field\Field
+	 * @return \Carbon_Fields\Field\Field
 	 */
 	public function get_field_in_container( $field_name, $container_id, $include_nested_fields = true ) {
 		$containers = $this->get_containers();
@@ -133,7 +133,7 @@ class Repository {
 	 * @param  string                    $field_name
 	 * @param  string                    $container_type
 	 * @param  bool                      $include_nested_fields
-	 * @return Carbon_Fields\Field\Field
+	 * @return \Carbon_Fields\Field\Field
 	 */
 	public function get_field_in_containers( $field_name, $container_type = null, $include_nested_fields = true ) {
 		$containers = $this->get_containers( $container_type );
@@ -156,10 +156,11 @@ class Repository {
 	/**
 	 * Return all currently active containers
 	 *
-	 * @return array
+	 * @return Container[]
 	 */
 	public function get_active_containers() {
 		return array_filter( $this->containers, function( $container ) {
+			/** @var Container $container */
 			return $container->is_active();
 		} );
 	}
@@ -168,6 +169,7 @@ class Repository {
 	 * Check if container identificator id is unique
 	 *
 	 * @param string $id
+	 * @return bool
 	 */
 	public function is_unique_container_id( $id ) {
 		return ! in_array( $id, $this->registered_container_ids );
@@ -177,6 +179,7 @@ class Repository {
 	 * Generate a unique container identificator id based on container title
 	 *
 	 * @param string $title
+	 * @return string
 	 */
 	public function get_unique_container_id( $title ) {
 		$id = remove_accents( $title );
@@ -193,7 +196,7 @@ class Repository {
 			$id_suffix = $wids;
 			$id = substr( $id, 0, -strlen( $wids ) );
 		}
-		
+
 		$id = preg_replace( '~[\s]+~', '_', $id );
 		$id = preg_replace( '~[^\w\-\_]+~', '', $id );
 

--- a/core/Datastore/Datastore_Holder_Interface.php
+++ b/core/Datastore/Datastore_Holder_Interface.php
@@ -15,6 +15,7 @@ interface Datastore_Holder_Interface {
 	 * Set datastore instance
 	 *
 	 * @param Datastore_Interface $datastore
+	 * @param boolean             $set_as_default
 	 * @return object $this
 	 */
 	public function set_datastore( Datastore_Interface $datastore, $set_as_default );

--- a/core/Datastore/Key_Value_Datastore.php
+++ b/core/Datastore/Key_Value_Datastore.php
@@ -15,7 +15,7 @@ abstract class Key_Value_Datastore extends Datastore {
 	/**
 	 * Key Toolset for key generation and comparison utilities
 	 *
-	 * @var Key_Toolset
+	 * @var \Carbon_Fields\Toolset\Key_Toolset
 	 */
 	protected $key_toolset;
 
@@ -55,7 +55,7 @@ abstract class Key_Value_Datastore extends Datastore {
 	 * Convert a cascading storage array to a value tree array
 	 *
 	 * @see Internal Glossary in DEVELOPMENT.MD
-	 * @param array<stdClass> $storage_array
+	 * @param \stdClass[] $storage_array
 	 * @return array
 	 */
 	protected function cascading_storage_array_to_value_tree_array( $storage_array ) {
@@ -137,7 +137,7 @@ abstract class Key_Value_Datastore extends Datastore {
 	 *
 	 * @param Field $field The field to retrieve value for.
 	 * @param array $storage_key_patterns
-	 * @return array<stdClass> Array of {key, value} objects
+	 * @return \stdClass[] Array of {key, value} objects
 	 */
 	abstract protected function get_storage_array( Field $field, $storage_key_patterns );
 

--- a/core/Datastore/Meta_Datastore.php
+++ b/core/Datastore/Meta_Datastore.php
@@ -19,7 +19,7 @@ abstract class Meta_Datastore extends Key_Value_Datastore {
 	 *
 	 * @param Field $field The field to retrieve value for.
 	 * @param array $storage_key_patterns
-	 * @return array<stdClass> Array of {key, value} objects
+	 * @return \stdClass[] Array of {key, value} objects
 	 */
 	protected function get_storage_array( Field $field, $storage_key_patterns ) {
 		global $wpdb;
@@ -62,7 +62,7 @@ abstract class Meta_Datastore extends Key_Value_Datastore {
 		global $wpdb;
 
 		$storage_key_patterns = $this->key_toolset->get_storage_key_deleter_patterns(
-			is_a( $field, 'Carbon_Fields\\Field\\Complex_Field' ),
+			( $field instanceof \Carbon_Fields\Field\Complex_Field ),
 			$field->is_simple_root_field(),
 			$this->get_full_hierarchy_for_field( $field ),
 			$this->get_full_hierarchy_index_for_field( $field )

--- a/core/Datastore/Theme_Options_Datastore.php
+++ b/core/Datastore/Theme_Options_Datastore.php
@@ -107,7 +107,7 @@ class Theme_Options_Datastore extends Key_Value_Datastore {
 		global $wpdb;
 
 		$storage_key_patterns = $this->key_toolset->get_storage_key_deleter_patterns(
-			is_a( $field, 'Carbon_Fields\\Field\\Complex_Field' ),
+			( $field instanceof \Carbon_Fields\Field\Complex_Field ),
 			$field->is_simple_root_field(),
 			$this->get_full_hierarchy_for_field( $field ),
 			$this->get_full_hierarchy_index_for_field( $field )

--- a/core/Datastore/Widget_Datastore.php
+++ b/core/Datastore/Widget_Datastore.php
@@ -77,7 +77,7 @@ class Widget_Datastore extends Key_Value_Datastore {
 	 */
 	public function delete( Field $field ) {
 		$storage_key_patterns = $this->key_toolset->get_storage_key_deleter_patterns(
-			is_a( $field, 'Carbon_Fields\\Field\\Complex_Field' ),
+			( $field instanceof \Carbon_Fields\Field\Complex_Field ),
 			$field->is_simple_root_field(),
 			$this->get_full_hierarchy_for_field( $field ),
 			$this->get_full_hierarchy_index_for_field( $field )

--- a/core/Event/Emitter.php
+++ b/core/Event/Emitter.php
@@ -4,12 +4,13 @@ namespace Carbon_Fields\Event;
 
 class Emitter {
 
+	/**
+	 * @var Listener[]
+	 */
 	protected $listeners = array();
 
 	/**
 	 * Broadcast an event
-	 *
-	 * @return mixed
 	 */
 	public function emit() {
 		$args = func_get_args();
@@ -60,6 +61,7 @@ class Emitter {
 		}
 
 		$this->listeners[ $event ] = array_filter( $listeners, function( $listener ) {
+			/** @var Listener $listener */
 			return $listener->is_valid();
 		} );
 	}
@@ -68,6 +70,7 @@ class Emitter {
 	 * Add a listener to an event
 	 *
 	 * @param string   $event
+	 * @param Listener $listener
 	 * @return Listener $listener
 	 */
 	public function add_listener( $event, $listener ) {

--- a/core/Exception/Incorrect_Syntax_Exception.php
+++ b/core/Exception/Incorrect_Syntax_Exception.php
@@ -9,6 +9,9 @@ class Incorrect_Syntax_Exception extends \Exception {
 
 	/**
 	 * Throw an exception when WP_DEBUG is enabled, and show a friendly admin notice otherwise
+	 *
+	 * @param string $message
+	 * @param int    $code    (optional)
 	 */
 	public static function raise( $message, $code = null ) {
 		if ( empty( static::$errors ) ) {

--- a/core/Field.php
+++ b/core/Field.php
@@ -5,6 +5,34 @@ namespace Carbon_Fields;
 /**
  * Field proxy factory class.
  * Used for shorter namespace access when creating a field.
+ *
+ * @method static \Carbon_Fields\Field\Association_Field make_association( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Checkbox_Field make_checkbox( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Color_Field make_color( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Complex_Field make_complex( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Date_Field make_date( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Date_Time_Field make_date_time( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\File_Field make_file( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Footer_Scripts_Field make_footer_scripts( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Gravity_Form_Field make_gravity_form( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Header_Scripts_Field make_header_scripts( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Hidden_Field make_hidden( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Html_Field make_html( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Image_Field make_image( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Map_Field make_map( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Media_Gallery_Field make_media_gallery( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Multiselect_Field make_multiselect( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\OEmbed_Field make_oembed( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Radio_Field make_radio( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Radio_Image_Field make_radio_image( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Rich_Text_Field make_rich_text( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Select_Field make_select( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Separator_Field make_separator( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Set_Field make_set( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Sidebar_Field make_sidebar( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Text_Field make_text( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Textarea_Field make_textarea( string $name, string $label = null )
+ * @method static \Carbon_Fields\Field\Time_Field make_time( string $name, string $label = null )
  */
 class Field {
 
@@ -26,5 +54,21 @@ class Field {
 	 */
 	public static function make() {
 		return call_user_func_array( array( get_class(), 'factory' ), func_get_args() );
+	}
+
+	/**
+	 * @param string $method
+	 * @param array $arguments
+	 *
+	 * @return mixed
+	 */
+	public static function __callStatic( $method, $arguments ) {
+		if ( strpos( $method, 'make_' ) === 0 ) {
+			$raw_type = substr_replace( $method, '', 0, 5 );
+			array_unshift( $arguments, $raw_type );
+			return call_user_func_array( array( get_class(), 'factory' ), $arguments );
+		} else {
+			trigger_error( sprintf( 'Call to undefined function: %s::%s().', get_class(), $method ), E_USER_ERROR );
+		}
 	}
 }

--- a/core/Field/Association_Field.php
+++ b/core/Field/Association_Field.php
@@ -20,7 +20,7 @@ class Association_Field extends Field {
 	/**
 	 * WP_Toolset instance for WP data loading
 	 *
-	 * @var Carbon_Fields\Toolset\WP_Toolset
+	 * @var \Carbon_Fields\Toolset\WP_Toolset
 	 */
 	protected $wp_toolset;
 
@@ -109,6 +109,7 @@ class Association_Field extends Field {
 	/**
 	 * Get value string for legacy value
 	 *
+	 * @param string $legacy_value
 	 * @return string
 	 */
 	protected function get_value_string_for_legacy_value( $legacy_value ) {
@@ -311,8 +312,7 @@ class Association_Field extends Field {
 	/**
 	 * Get the items per page.
 	 *
-	 * @param  int   $items_per_page
-	 * @return self  $this
+	 * @return int
 	 */
 	public function get_items_per_page() {
 		return $this->items_per_page;
@@ -731,7 +731,7 @@ class Association_Field extends Field {
 	/**
 	 * Retrieve the edit link of a particular object.
 	 *
-	 * @param  string $type Object type.
+	 * @param  array $type Object type.
 	 * @param  int $id      ID of the object.
 	 * @return string       URL of the edit link.
 	 */
@@ -765,7 +765,7 @@ class Association_Field extends Field {
 	/**
 	 * Prepares an option of type 'post' for JS usage.
 	 *
-	 * @param  array  $data
+	 * @param  \stdClass  $data
 	 * @return array
 	 */
 	public function format_post_option( $data ) {
@@ -784,7 +784,7 @@ class Association_Field extends Field {
 	/**
 	 * Prepares an option of type 'term' for JS usage.
 	 *
-	 * @param  array  $data
+	 * @param  \stdClass  $data
 	 * @return array
 	 */
 	public function format_term_option( $data ) {
@@ -794,7 +794,7 @@ class Association_Field extends Field {
 			'thumbnail'  => '',
 			'type'       => $data->type,
 			'subtype'    => $data->subtype,
-			'label'      => $this->get_item_label( $data, $data->type, $data->subtype ),
+			'label'      => $this->get_item_label( $data->ID, $data->type, $data->subtype ),
 			'is_trashed' => false,
 			'edit_link'  => $this->get_object_edit_link( get_object_vars( $data ), $data->ID ),
 		);
@@ -803,7 +803,7 @@ class Association_Field extends Field {
 	/**
 	 * Prepares an option of type 'comment' for JS usage.
 	 *
-	 * @param  array  $data
+	 * @param  \stdClass  $data
 	 * @return array
 	 */
 	public function format_comment_option( $data ) {
@@ -822,7 +822,7 @@ class Association_Field extends Field {
 	/**
 	 * Prepares an option of type 'user' for JS usage.
 	 *
-	 * @param  array  $data
+	 * @param  \stdClass  $data
 	 * @return array
 	 */
 	public function format_user_option( $data ) {

--- a/core/Field/Complex_Field.php
+++ b/core/Field/Complex_Field.php
@@ -3,9 +3,6 @@
 namespace Carbon_Fields\Field;
 
 use Carbon_Fields\Datastore\Datastore_Interface;
-use Carbon_Fields\Helper\Helper;
-use Carbon_Fields\Field\Field;
-use Carbon_Fields\Field\Group_Field;
 use Carbon_Fields\Value_Set\Value_Set;
 use Carbon_Fields\Exception\Incorrect_Syntax_Exception;
 
@@ -231,7 +228,7 @@ class Complex_Field extends Field {
 
 		$reserved_names = array( Value_Set::VALUE_PROPERTY, static::TYPE_PROPERTY );
 		foreach ( $fields as $field ) {
-			/** @var \Carbon_Fields\Field\Field $field */
+			/** @var Field $field */
 			if ( in_array( $field->get_base_name(), $reserved_names ) ) {
 				Incorrect_Syntax_Exception::raise( '"' . $field->get_base_name() . '" is a reserved keyword for Complex fields and cannot be used for a field name.' );
 				return $this;

--- a/core/Field/Complex_Field.php
+++ b/core/Field/Complex_Field.php
@@ -119,6 +119,7 @@ class Complex_Field extends Field {
 	/**
 	 * Set array of hierarchy field names
 	 *
+	 * @param array $hierarchy
 	 * @return self  $this
 	 */
 	public function set_hierarchy( $hierarchy ) {
@@ -230,6 +231,7 @@ class Complex_Field extends Field {
 
 		$reserved_names = array( Value_Set::VALUE_PROPERTY, static::TYPE_PROPERTY );
 		foreach ( $fields as $field ) {
+			/** @var \Carbon_Fields\Field\Field $field */
 			if ( in_array( $field->get_base_name(), $reserved_names ) ) {
 				Incorrect_Syntax_Exception::raise( '"' . $field->get_base_name() . '" is a reserved keyword for Complex fields and cannot be used for a field name.' );
 				return $this;
@@ -303,6 +305,7 @@ class Complex_Field extends Field {
 	 *  - plural_name - the plural entries label
 	 *
 	 * @param  array $labels Labels
+	 * @return Complex_Field
 	 */
 	public function setup_labels( $labels ) {
 		$this->labels = array_merge( $this->labels, $labels );
@@ -392,7 +395,7 @@ class Complex_Field extends Field {
 				$tmp_field = $this->get_clone_under_field_in_hierarchy( $field, $this, $input_group_index );
 
 				$tmp_field->set_value_from_input( $values );
-				if ( is_a( $tmp_field, get_class() ) ) {
+				if ( $tmp_field instanceof Complex_Field ) {
 					$value_group[ $tmp_field->get_base_name() ] = $tmp_field->get_value_tree();
 				} else {
 					$value_group[ $tmp_field->get_base_name() ] = $tmp_field->get_full_value();
@@ -424,7 +427,7 @@ class Complex_Field extends Field {
 			$field_groups = $this->get_prefilled_groups( $this->get_value(), $this->get_value_tree() );
 			foreach ( $field_groups as $group_index => $fields ) {
 				foreach ( $fields as $field ) {
-					if ( ! is_a( $field, __NAMESPACE__ . '\\Field' ) ) {
+					if ( ! ( $field instanceof Field ) ) {
 						continue;
 					}
 					$field->save();
@@ -443,7 +446,7 @@ class Complex_Field extends Field {
 		foreach ( $field_groups as $group_index => $field_group ) {
 			$value[ $group_index ] = array();
 			foreach ( $field_group as $key => $field ) {
-				if ( is_a( $field, __NAMESPACE__ . '\\Field' ) ) {
+				if ( $field instanceof Field ) {
 					$value[ $group_index ][ $field->get_base_name() ] = $field->get_formatted_value();
 				} else {
 					if ( $key === Value_Set::VALUE_PROPERTY ) {
@@ -517,6 +520,7 @@ class Complex_Field extends Field {
 	 * Set the full value tree of all groups and their fields
 	 *
 	 * @see    Internal Glossary in DEVELOPMENT.MD
+	 * @param array $value_tree
 	 * @return self     $this
 	 */
 	public function set_value_tree( $value_tree ) {
@@ -556,7 +560,7 @@ class Complex_Field extends Field {
 			);
 
 			foreach ( $fields as $field ) {
-				if ( ! is_a( $field, __NAMESPACE__ . '\\Field' ) ) {
+				if ( ! ( $field instanceof Field ) ) {
 					continue;
 				}
 				$data['fields'][] = $field->to_json( false );

--- a/core/Field/Date_Field.php
+++ b/core/Field/Date_Field.php
@@ -48,7 +48,7 @@ class Date_Field extends Field {
 	public function set_value_from_input( $input ) {
 		if ( isset( $input[ $this->get_name() ] ) ) {
 			$date = \DateTime::createFromFormat( $this->input_format_php, $input[ $this->get_name() ] );
-			$value = ( is_a( $date, 'DateTime' ) ) ? $date->format( $this->storage_format ) : '';
+			$value = ( $date instanceof \DateTime ) ? $date->format( $this->storage_format ) : '';
 			$this->set_value( $value );
 		} else {
 			$this->clear_value();
@@ -65,7 +65,7 @@ class Date_Field extends Field {
 		$value = $this->get_value();
 		if ( ! empty( $value ) ) {
 			$date = \DateTime::createFromFormat( $this->storage_format, $value );
-			$value = ( is_a( $date, 'DateTime' ) ) ? $date->format( $this->input_format_php ) : '';
+			$value = ( $date instanceof \DateTime ) ? $date->format( $this->input_format_php ) : '';
 		}
 
 		$field_data = array_merge( $field_data, array(

--- a/core/Field/Date_Field.php
+++ b/core/Field/Date_Field.php
@@ -102,7 +102,9 @@ class Date_Field extends Field {
 	/**
 	 * Get the expected input format in php and js variants
 	 *
-	 * @return array
+	 * @param string $php_format
+	 * @param string $js_format
+	 * @return self $this
 	 */
 	public function get_input_format( $php_format, $js_format ) {
 		$this->input_format_php = $php_format;

--- a/core/Field/Field.php
+++ b/core/Field/Field.php
@@ -335,6 +335,7 @@ class Field implements Datastore_Holder_Interface {
 	/**
 	 * Set array of hierarchy field names
 	 *
+	 * @param array $hierarchy
 	 * @return self  $this
 	 */
 	public function set_hierarchy( $hierarchy ) {

--- a/core/Field/Field.php
+++ b/core/Field/Field.php
@@ -3,7 +3,6 @@
 namespace Carbon_Fields\Field;
 
 use Carbon_Fields\Carbon_Fields;
-use Carbon_Fields\Pimple\Container as PimpleContainer;
 use Carbon_Fields\Datastore\Datastore_Interface;
 use Carbon_Fields\Datastore\Datastore_Holder_Interface;
 use Carbon_Fields\Value_Set\Value_Set;
@@ -355,6 +354,7 @@ class Field implements Datastore_Holder_Interface {
 	/**
 	 * Set array of hierarchy indexes
 	 *
+	 * @param array $hierarchy_index
 	 * @return self  $this
 	 */
 	public function set_hierarchy_index( $hierarchy_index ) {
@@ -566,6 +566,9 @@ class Field implements Datastore_Holder_Interface {
 
 	/**
 	 * Alias for $this->get_value_set()->set( $value );
+	 *
+	 * @param mixed $value
+	 * @return self  $this
 	 */
 	public function set_value( $value ) {
 		$this->get_value_set()->set( $value );
@@ -592,7 +595,7 @@ class Field implements Datastore_Holder_Interface {
 	 * Set default field value
 	 *
 	 * @param  mixed $default_value
-	 * @return self  $this
+	 * @return $this
 	 */
 	public function set_default_value( $default_value ) {
 		$this->default_value = $default_value;
@@ -611,6 +614,7 @@ class Field implements Datastore_Holder_Interface {
 	/**
 	 * Set field base name as defined in the container.
 	 *
+	 * @param string $name
 	 * @return self  $this
 	 */
 	public function set_base_name( $name ) {
@@ -773,7 +777,7 @@ class Field implements Datastore_Holder_Interface {
 	/**
 	 * Return the field help text
 	 *
-	 * @return object $this
+	 * @return string
 	 */
 	public function get_help_text() {
 		return $this->help_text;
@@ -783,6 +787,7 @@ class Field implements Datastore_Holder_Interface {
 	 * Set additional text to be displayed during field render,
 	 * containing information and guidance for the user
 	 *
+	 * @param string $help_text
 	 * @return self  $this
 	 */
 	public function set_help_text( $help_text ) {
@@ -794,6 +799,7 @@ class Field implements Datastore_Holder_Interface {
 	 * Alias for set_help_text()
 	 *
 	 * @see set_help_text()
+	 * @param string $help_text
 	 * @return object $this
 	 */
 	public function help_text( $help_text ) {

--- a/core/Field/File_Field.php
+++ b/core/Field/File_Field.php
@@ -2,8 +2,6 @@
 
 namespace Carbon_Fields\Field;
 
-use Carbon_Fields\Helper\Helper;
-
 
 /**
  * File upload field class.

--- a/core/Field/File_Field.php
+++ b/core/Field/File_Field.php
@@ -23,6 +23,7 @@ class File_Field extends Field {
 	 * Change the type of the field
 	 *
 	 * @param string $type
+	 * @return File_Field
 	 */
 	public function set_type( $type ) {
 		$this->field_type = $type;
@@ -33,6 +34,7 @@ class File_Field extends Field {
 	 * Change the value type of the field.
 	 *
 	 * @param string $value_type
+	 * @return File_Field
 	 */
 	public function set_value_type( $value_type ) {
 		$this->value_type = $value_type;

--- a/core/Field/Group_Field.php
+++ b/core/Field/Group_Field.php
@@ -81,7 +81,7 @@ class Group_Field {
 	 */
 	public function add_fields( $fields ) {
 		foreach ( $fields as $field ) {
-			if ( ! is_a( $field, __NAMESPACE__ . '\\Field' ) ) {
+			if ( ! ( $field instanceof Field ) ) {
 				Incorrect_Syntax_Exception::raise( 'Object must be of type ' . __NAMESPACE__ . '\\Field' );
 			}
 
@@ -231,7 +231,7 @@ class Group_Field {
 	/**
 	 * Assign a DataStore instance for all group fields.
 	 *
-	 * @param  object  $datastore
+	 * @param  Datastore_Interface  $datastore
 	 * @param  boolean $set_as_default
 	 * @return self    $this
 	 */

--- a/core/Field/Hidden_Field.php
+++ b/core/Field/Hidden_Field.php
@@ -2,8 +2,6 @@
 
 namespace Carbon_Fields\Field;
 
-use Carbon_Fields\Exception\Incorrect_Syntax_Exception;
-
 /**
  * Hidden field class.
  */

--- a/core/Field/Map_Field.php
+++ b/core/Field/Map_Field.php
@@ -116,7 +116,7 @@ class Map_Field extends Field {
 	 * @param  string $lat  Latitude
 	 * @param  string $lng  Longitude
 	 * @param  int    $zoom Zoom level
-	 * @return self   $this
+	 * @return $this
 	 */
 	public function set_position( $lat, $lng, $zoom ) {
 		return $this->set_default_value( array_merge(

--- a/core/Field/Media_Gallery_Field.php
+++ b/core/Field/Media_Gallery_Field.php
@@ -65,6 +65,7 @@ class Media_Gallery_Field extends Field {
 	 * Change the type of the field
 	 *
 	 * @param string $type
+	 * @return Media_Gallery_Field
 	 */
 	public function set_type( $type ) {
 		$this->file_type = $type;

--- a/core/Field/Predefined_Options_Field.php
+++ b/core/Field/Predefined_Options_Field.php
@@ -113,6 +113,7 @@ abstract class Predefined_Options_Field extends Field {
 	 * Will also work with a callable that returns an array.
 	 *
 	 * @param array|callable $options
+	 * @param bool $stringify_value (optional)
 	 * @return array
 	 */
 	protected function parse_options( $options, $stringify_value = false ) {

--- a/core/Field/Scripts_Field.php
+++ b/core/Field/Scripts_Field.php
@@ -46,7 +46,7 @@ abstract class Scripts_Field extends Textarea_Field {
 	 * Display the field value in the front-end header.
 	 */
 	public function print_scripts() {
-		$is_valid_datastore = ( is_a( $this->get_datastore(), 'Carbon_Fields\\Datastore\\Theme_Options_Datastore' ) || is_a( $this->get_datastore(), 'Carbon_Fields\\Datastore\\Network_Datastore' ) );
+		$is_valid_datastore = ( $this->get_datastore() instanceof \Carbon_Fields\Datastore\Theme_Options_Datastore || $this->get_datastore() instanceof \Carbon_Fields\Datastore\Network_Datastore );
 		if ( ! $this->get_datastore() || ! $is_valid_datastore ) {
 			return;
 		}

--- a/core/Helper/Helper.php
+++ b/core/Helper/Helper.php
@@ -17,7 +17,7 @@ class Helper {
 	 * @param  string  $container_type Container type to search in. Optional if $container_id is supplied
 	 * @param  string  $container_id   Container id to search in. Optional if $container_type is supplied
 	 * @param  string  $field_name     Field name to search for
-	 * @return boolean
+	 * @return \Carbon_Fields\Field\Field
 	 */
 	public static function get_field( $container_type, $container_id, $field_name ) {
 		\Carbon_Fields\Carbon_Fields::verify_fields_registered();
@@ -37,7 +37,7 @@ class Helper {
 	 * @param  string $container_type Container type to search in. Optional if $container_id is supplied
 	 * @param  string $container_id   Container id to search in. Optional if $container_type is supplied
 	 * @param  string $field_name     Field name to search for
-	 * @return mixed
+	 * @return \Carbon_Fields\Field\Field
 	 */
 	public static function get_field_clone( $object_id, $container_type, $container_id, $field_name ) {
 		$field = static::get_field( $container_type, $container_id, $field_name );
@@ -63,7 +63,7 @@ class Helper {
 	 * @param  string   $container_id   Container id to search in. Optional if $container_type is supplied
 	 * @param  string   $field_name     Field name to search for
 	 * @param  \Closure $action         Action to execute
-	 * @return void
+	 * @return void|mixed
 	 */
 	public static function with_field_clone( $object_id, $container_type, $container_id, $field_name, $action ) {
 		$field = static::get_field( $container_type, $container_id, $field_name );
@@ -108,7 +108,7 @@ class Helper {
 				if ( ! $field ) {
 					return '';
 				}
-
+				/** @var \Carbon_Fields\Field\Field $field */
 				$field->load();
 				return $field->get_formatted_value();
 			}
@@ -137,7 +137,7 @@ class Helper {
 					Incorrect_Syntax_Exception::raise( 'Could not find a field which satisfies the supplied pattern ' . $container_message . ': ' . $field_name );
 					return;
 				}
-
+				/** @var \Carbon_Fields\Field\Field $field */
 				$field->set_value( $value );
 				$field->save();
 			}
@@ -178,7 +178,7 @@ class Helper {
 	 * @param  string $container_id
 	 */
 	public static function set_post_meta( $id, $name, $value, $container_id = '' ) {
-		return static::set_value( $id, 'post_meta', $container_id, $name, $value );
+		static::set_value( $id, 'post_meta', $container_id, $name, $value );
 	}
 
 	/**
@@ -200,7 +200,7 @@ class Helper {
 	 * @param  string $container_id
 	 */
 	public static function set_theme_option( $name, $value, $container_id = '' ) {
-		return static::set_value( null, 'theme_options', $container_id, $name, $value );
+		static::set_value( null, 'theme_options', $container_id, $name, $value );
 	}
 
 	/**
@@ -232,11 +232,11 @@ class Helper {
 	 *
 	 * @param  string $id           Site ID
 	 * @param  string $name         Field name
+	 * @param  array  $value
 	 * @param  string $container_id
-	 * @return mixed
 	 */
 	public static function set_network_option( $id, $name, $value, $container_id = '' ) {
-		return static::set_value( $id, 'network', $container_id, $name, $value );
+		static::set_value( $id, 'network', $container_id, $name, $value );
 	}
 
 	/**
@@ -260,7 +260,7 @@ class Helper {
 	 * @param  string $container_id
 	 */
 	public static function set_term_meta( $id, $name, $value, $container_id = '' ) {
-		return static::set_value( $id, 'term_meta', $container_id, $name, $value );
+		static::set_value( $id, 'term_meta', $container_id, $name, $value );
 	}
 
 	/**
@@ -284,7 +284,7 @@ class Helper {
 	 * @param  string $container_id
 	 */
 	public static function set_user_meta( $id, $name, $value, $container_id = '' ) {
-		return static::set_value( $id, 'user_meta', $container_id, $name, $value );
+		static::set_value( $id, 'user_meta', $container_id, $name, $value );
 	}
 
 	/**
@@ -308,7 +308,7 @@ class Helper {
 	 * @param  string $container_id
 	 */
 	public static function set_comment_meta( $id, $name, $value, $container_id = '' ) {
-		return static::set_value( $id, 'comment_meta', $container_id, $name, $value );
+		static::set_value( $id, 'comment_meta', $container_id, $name, $value );
 	}
 
 	/**
@@ -332,7 +332,7 @@ class Helper {
 	 * @param  string $container_id
 	 */
 	public static function set_nav_menu_item_meta( $id, $name, $value, $container_id = '' ) {
-		return static::set_value( $id, 'nav_menu_item', $container_id, $name, $value );
+		static::set_value( $id, 'nav_menu_item', $container_id, $name, $value );
 	}
 
 	/**
@@ -561,7 +561,7 @@ class Helper {
 	 *
 	 * @param  string  $id
 	 * @param  string  $type Value Type. Can be either id or url.
-	 * @return boolean
+	 * @return array
 	 */
 	public static function get_attachment_metadata( $id, $type ) {
 		$attachment_metadata = array(

--- a/core/Libraries/Sidebar_Manager/Sidebar_Manager.php
+++ b/core/Libraries/Sidebar_Manager/Sidebar_Manager.php
@@ -89,7 +89,7 @@ class Sidebar_Manager {
 	 * @see Sidebar_Manager::register_sidebars()
 	 * @param string $id Sidebar ID
 	 * @param string $name Sidebar Name
-	 * @return bool|WP_Error
+	 * @return array|\WP_Error
 	 */
 	public function add_sidebar( $name, $id = '' ) {
 		$registered_sidebars = $this->get_sidebars();
@@ -123,7 +123,7 @@ class Sidebar_Manager {
 	 *
 	 * @see Sidebar_Manager::register_sidebars()
 	 * @param string $id Sidebar ID
-	 * @return bool|WP_Error
+	 * @return bool|\WP_Error
 	 */
 	public function remove_sidebar( $id ) {
 		$registered_sidebars = $this->get_sidebars();

--- a/core/Loader/Loader.php
+++ b/core/Loader/Loader.php
@@ -294,6 +294,7 @@ class Loader {
 		$container_id = $_GET['container_id'];
 		$field_name   = $_GET['field_name'];
 
+		/** @var \Carbon_Fields\Field\Association_Field $field */
 		$field = Helper::get_field( null, $container_id, $field_name );
 
 		return wp_send_json_success( $field->get_options( array(

--- a/core/Provider/Container_Condition_Provider.php
+++ b/core/Provider/Container_Condition_Provider.php
@@ -275,7 +275,7 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 * Filter the Post_Meta_Container static condition types
 	 *
 	 * @param  array<string>                     $condition_types
-	 * @param  Carbon_Fields\Container\Container $container
+	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
 	public function filter_post_meta_container_static_condition_types( $condition_types, $container_type, $container ) {
@@ -288,8 +288,9 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	/**
 	 * Filter the Post_Meta_Container dynamic condition types
 	 *
-	 * @param  array<string>                     $condition_types
-	 * @param  Carbon_Fields\Container\Container $container
+	 * @param  array<string>                      $condition_types
+	 * @param  string                             $container_type
+	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
 	public function filter_post_meta_container_dynamic_condition_types( $condition_types, $container_type, $container ) {
@@ -302,8 +303,9 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	/**
 	 * Filter the Term_Meta_Container static condition types
 	 *
-	 * @param  array<string>                     $condition_types
-	 * @param  Carbon_Fields\Container\Container $container
+	 * @param  array<string>                      $condition_types
+	 * @param  string                             $container_type
+	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
 	public function filter_term_meta_container_static_condition_types( $condition_types, $container_type, $container ) {
@@ -316,8 +318,9 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	/**
 	 * Filter the Term_Meta_Container dynamic condition types
 	 *
-	 * @param  array<string>                     $condition_types
-	 * @param  Carbon_Fields\Container\Container $container
+	 * @param  array<string>                      $condition_types
+	 * @param  string                             $container_type
+	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
 	public function filter_term_meta_container_dynamic_condition_types( $condition_types, $container_type, $container ) {
@@ -330,8 +333,9 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	/**
 	 * Filter the User_Meta_Container static condition types
 	 *
-	 * @param  array<string>                     $condition_types
-	 * @param  Carbon_Fields\Container\Container $container
+	 * @param  array<string>                      $condition_types
+	 * @param  string                             $container_type
+	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
 	public function filter_user_meta_container_static_condition_types( $condition_types, $container_type, $container ) {
@@ -344,8 +348,9 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	/**
 	 * Filter the User_Meta_Container dynamic condition types
 	 *
-	 * @param  array<string>                     $condition_types
-	 * @param  Carbon_Fields\Container\Container $container
+	 * @param  array<string>                      $condition_types
+	 * @param  string                             $container_type
+	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
 	public function filter_user_meta_container_dynamic_condition_types( $condition_types, $container_type, $container ) {
@@ -358,8 +363,9 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	/**
 	 * Filter the Theme_Options_Container static condition types
 	 *
-	 * @param  array<string>                     $condition_types
-	 * @param  Carbon_Fields\Container\Container $container
+	 * @param  array<string>                      $condition_types
+	 * @param  string                             $container_type
+	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
 	public function filter_theme_options_container_static_condition_types( $condition_types, $container_type, $container ) {

--- a/core/REST_API/Decorator.php
+++ b/core/REST_API/Decorator.php
@@ -79,6 +79,7 @@ class Decorator {
 	/**
 	 * Get Post Meta Container visibility settings
 	 *
+	 * @param \Carbon_Fields\Container\Post_Meta_Container $container
 	 * @return array
 	 */
 	public static function get_post_meta_container_settings( $container ) {
@@ -88,6 +89,7 @@ class Decorator {
 	/**
 	 * Get Term Meta Container visibility settings
 	 *
+	 * @param \Carbon_Fields\Container\Term_Meta_Container $container
 	 * @return array
 	 */
 	public static function get_term_meta_container_settings( $container ) {
@@ -97,6 +99,7 @@ class Decorator {
 	/**
 	 * Get User Meta Container visibility settings
 	 *
+	 * @param \Carbon_Fields\Container\User_Meta_Container $container
 	 * @return string
 	 */
 	public static function get_user_meta_container_settings( $container ) {
@@ -106,6 +109,7 @@ class Decorator {
 	/**
 	 * Get Comment Meta Container visibility settings
 	 *
+	 * @param \Carbon_Fields\Container\Comment_Meta_Container $container
 	 * @return string
 	 */
 	public static function get_comment_meta_container_settings( $container ) {

--- a/core/REST_API/Router.php
+++ b/core/REST_API/Router.php
@@ -108,6 +108,8 @@ class Router {
 
 	/**
 	 * Set routes
+	 *
+	 * @param array $routes
 	 */
 	public function set_routes( $routes ) {
 		$this->routes = $routes;
@@ -124,6 +126,8 @@ class Router {
 
 	/**
 	 * Set version
+	 *
+	 * @param string $version
 	 */
 	public function set_version( $version ) {
 		$this->version = $version;
@@ -140,6 +144,8 @@ class Router {
 
 	/**
 	 * Set vendor
+	 *
+	 * @param string $vendor
 	 */
 	public function set_vendor( $vendor ) {
 		$this->vendor = $vendor;
@@ -191,8 +197,8 @@ class Router {
 	/**
 	 * Proxy method for handling get/set for theme options
 	 *
-	 * @param  WP_REST_Request $request
-	 * @return array|WP_REST_Response
+	 * @param  \WP_REST_Request $request
+	 * @return array|\WP_REST_Response
 	 */
 	public function options_accessor( $request ) {
 		$request_type = $request->get_method();
@@ -207,7 +213,7 @@ class Router {
 	/**
 	 * Proxy method for handling theme options permissions
 	 *
-	 * @param  WP_REST_Request $request
+	 * @param  \WP_REST_Request $request
 	 * @return bool
 	 */
 	public function options_permission( $request ) {
@@ -297,6 +303,7 @@ class Router {
 		$options      = isset( $_GET['options'] ) ? explode( ';', $_GET['options'] ) : array();
 		$return_value = array();
 
+		/** @var \Carbon_Fields\Field\Association_Field $field */
 		$field = Helper::get_field( null, $container_id, $field_id );
 
 		$options = array_map( function ( $option ) {
@@ -351,8 +358,8 @@ class Router {
 	/**
 	 * Set Carbon theme options
 	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
+	 * @param \WP_REST_Request $request Full data about the request.
+	 * @return \WP_Error|\WP_REST_Response
 	 */
 	protected function set_options( $request ) {
 		$options = $request->get_params();
@@ -377,8 +384,8 @@ class Router {
 	 *
 	 * @see https://github.com/WordPress/WordPress/blob/master/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php#L78-L116
 	 *
-	 * @param  WP_REST_Request
-	 * @return true|WP_Error
+	 * @param  \WP_REST_Request
+	 * @return true|\WP_Error
 	 */
 	public function block_renderer_permission( $request ) {
 		global $post;
@@ -443,8 +450,8 @@ class Router {
 	 *
 	 * @see https://github.com/WordPress/WordPress/blob/master/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php#L118-L154
 	 *
-	 * @param  WP_REST_Request $request
-	 * @return WP_REST_Response|WP_Error
+	 * @param  \WP_REST_Request $request
+	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function block_renderer( $request ) {
 		global $post;

--- a/core/Service/Legacy_Storage_Service_v_1_5.php
+++ b/core/Service/Legacy_Storage_Service_v_1_5.php
@@ -8,7 +8,6 @@ use Carbon_Fields\Container\Repository as ContainerRepository;
 use Carbon_Fields\Value_Set\Value_Set;
 use Carbon_Fields\Toolset\Key_Toolset;
 use Carbon_Fields\Datastore\Datastore_Interface;
-use Carbon_Fields\Exception\Incorrect_Syntax_Exception;
 
 /*
  * Service which provides the ability to do meta queries for multi-value fields and nested fields
@@ -47,6 +46,7 @@ class Legacy_Storage_Service_v_1_5 extends Service {
 	 * Service constructor
 	 *
 	 * @param ContainerRepository $container_repository
+	 * @param Key_Toolset         $key_toolset
 	 */
 	public function __construct( ContainerRepository $container_repository, Key_Toolset $key_toolset ) {
 		$this->container_repository = $container_repository;
@@ -107,7 +107,7 @@ class Legacy_Storage_Service_v_1_5 extends Service {
 		$permutations = array();
 
 		foreach ( $fields as $field ) {
-			if ( is_a( $field, 'Carbon_Fields\\Field\\Complex_Field' ) ) {
+			if ( $field instanceof \Carbon_Fields\Field\Complex_Field ) {
 				$group_names = $field->get_group_names();
 				foreach ( $group_names as $group_name ) {
 					$group = $field->get_group_by_name( $group_name );
@@ -149,12 +149,12 @@ class Legacy_Storage_Service_v_1_5 extends Service {
 			'table_value_column' => '',
 		);
 
-		if ( is_a( $datastore, 'Carbon_Fields\\Datastore\\Theme_Options_Datastore' ) ) {
+		if ( $datastore instanceof \Carbon_Fields\Datastore\Theme_Options_Datastore ) {
 			$details['prefix'] = '';
 			$details['table_name'] = $wpdb->options;
 			$details['table_key_column'] = 'option_name';
 			$details['table_value_column'] = 'option_value';
-		} else if ( is_a( $datastore, 'Carbon_Fields\\Datastore\\Meta_Datastore' ) ) {
+		} else if ( $datastore instanceof \Carbon_Fields\Datastore\Meta_Datastore ) {
 			$details['table_name'] = $datastore->get_table_name();
 			$details['table_id_column'] = $datastore->get_table_field_name();
 			$details['table_key_column'] = 'meta_key';
@@ -176,7 +176,7 @@ class Legacy_Storage_Service_v_1_5 extends Service {
 		$field_key_pattern = $key_prefix . $field->get_base_name();
 		$comparisons = array();
 
-		if ( is_a( $field, 'Carbon_Fields\\Field\\Complex_Field' ) ) {
+		if ( $field instanceof \Carbon_Fields\Field\Complex_Field ) {
 			$groups = $field->get_group_names();
 			foreach ( $groups as $group_name ) {
 				$underscored_group_name = preg_replace( '/^_{0,1}/', '_', $group_name ); // ensure first character is underscore
@@ -186,7 +186,7 @@ class Legacy_Storage_Service_v_1_5 extends Service {
 			$comparisons[] = ' `' . $key_column . '` = "' . esc_sql( $field_key_pattern ) . '" ';
 		}
 
-		if ( is_a( $field, 'Carbon_Fields\\Field\\Map_Field' ) ) {
+		if ( $field instanceof \Carbon_Fields\Field\Map_Field ) {
 			foreach ( $this->map_keys as $map_key ) {
 				$comparisons[] = ' `' . $key_column . '` = "' . esc_sql( $field_key_pattern . '-' . $map_key ) . '" ';
 			}

--- a/core/Service/Meta_Query_Service.php
+++ b/core/Service/Meta_Query_Service.php
@@ -60,6 +60,9 @@ class Meta_Query_Service extends Service {
 	/**
 	 * Recursive function to replace meta keys in meta_query arrays
 	 *
+	 * @param $condition
+	 * @param $container_type
+	 *
 	 * @return array
 	 */
 	protected function filter_meta_query_array( $condition, $container_type ) {
@@ -109,6 +112,8 @@ class Meta_Query_Service extends Service {
 
 	/**
 	 * Hook to pre_get_posts to filter the meta_query array
+	 *
+	 * @param \WP_Query $query
 	 */
 	public function hook_pre_get_posts( $query ) {
 		$meta_query = $query->get( 'meta_query' );
@@ -124,6 +129,8 @@ class Meta_Query_Service extends Service {
 
 	/**
 	 * Hook to pre_get_terms to filter the meta_query array
+	 *
+	 * @param \WP_Query $query
 	 */
 	public function hook_pre_get_terms( $query ) {
 		$meta_query = ! empty( $query->query_vars['meta_query'] ) ? $query->query_vars['meta_query'] : array();
@@ -139,6 +146,8 @@ class Meta_Query_Service extends Service {
 
 	/**
 	 * Hook to pre_get_users to filter the meta_query array
+	 *
+	 * @param \WP_Query $query
 	 */
 	public function hook_pre_get_users( $query ) {
 		$meta_query = $query->get( 'meta_query' );

--- a/core/Service/Revisions_Service.php
+++ b/core/Service/Revisions_Service.php
@@ -17,12 +17,12 @@ class Revisions_Service extends Service {
 	}
 
 	protected function disabled() {
-		remove_filter( 'carbon_get_post_meta_post_id', array( $this, 'update_post_id_on_preview' ), 10, 3 );
-		remove_action( 'carbon_fields_post_meta_container_saved', array( $this, 'maybe_copy_meta_to_revision' ), 10, 2 );
-		remove_filter('_wp_post_revision_fields', array( $this, 'maybe_save_revision' ), 10, 2 );
-		remove_filter('_wp_post_revision_fields', array( $this, 'add_fields_to_revision' ), 10, 2 );
-		remove_action( 'wp_restore_post_revision', array( $this, 'restore_post_revision' ), 10, 2 );
-		remove_filter( 'wp_save_post_revision_check_for_changes', array( $this, 'check_for_changes' ), 10, 3 );
+		remove_filter( 'carbon_get_post_meta_post_id', array( $this, 'update_post_id_on_preview' ), 10 );
+		remove_action( 'carbon_fields_post_meta_container_saved', array( $this, 'maybe_copy_meta_to_revision' ), 10 );
+		remove_filter('_wp_post_revision_fields', array( $this, 'maybe_save_revision' ), 10 );
+		remove_filter('_wp_post_revision_fields', array( $this, 'add_fields_to_revision' ), 10 );
+		remove_action( 'wp_restore_post_revision', array( $this, 'restore_post_revision' ), 10 );
+		remove_filter( 'wp_save_post_revision_check_for_changes', array( $this, 'check_for_changes' ), 10 );
 	}
 
 	public function check_for_changes( $return, $last_revision, $post ) {
@@ -61,6 +61,10 @@ class Revisions_Service extends Service {
 		return $revision->ID;
 	}
 
+	/**
+	 * @param int $post_id
+	 * @param \Carbon_Fields\Container\Post_Meta_Container $container
+	 */
 	public function maybe_copy_meta_to_revision( $post_id, $container ) {
 		if ( ! $container || $container->get_revisions_disabled() ) {
 			return;
@@ -128,6 +132,14 @@ class Revisions_Service extends Service {
 		return $fields;
 	}
 
+	/**
+	 * @param mixed $value
+	 * @param string $field_name
+	 * @param \WP_Post $post
+	 * @param bool $direction
+	 *
+	 * @return int|mixed
+	 */
 	public function update_revision_field_value( $value, $field_name, $post = null, $direction = false ) {
 		if ( empty( $post ) ) {
 			return $value;
@@ -153,10 +165,12 @@ class Revisions_Service extends Service {
 		$repository = Carbon_Fields::resolve( 'container_repository' );
 		$containers = $repository->get_containers( 'post_meta' );
 		$containers = array_filter( $containers, function( $container ) {
+			/** @var \Carbon_Fields\Container\Post_Meta_Container $container */
 			return !$container->get_revisions_disabled();
 		} );
 		$fields = array();
 		foreach ( $containers as $container ) {
+			/** @var \Carbon_Fields\Container\Post_Meta_Container $container */
 			foreach ( $container->get_fields() as $field ) {
 				$fields[ $field->get_name() ] = $field->get_label();
 			}
@@ -192,11 +206,13 @@ class Revisions_Service extends Service {
 	    $repository = Carbon_Fields::resolve( 'container_repository' );
 	    $containers = $repository->get_containers( 'post_meta' );
 	    $containers = array_filter( $containers, function( $container ) {
+		    /** @var \Carbon_Fields\Container\Post_Meta_Container $container */
 	        return !$container->get_revisions_disabled();
 	    } );
 
 	    $field_keys = array();
 	    foreach ( $containers as $container ) {
+		    /** @var \Carbon_Fields\Container\Post_Meta_Container $container */
 	        foreach ( $container->get_fields() as $field ) {
 	            $field_keys[] = $field->get_name();
 	        }

--- a/core/Toolset/WP_Toolset.php
+++ b/core/Toolset/WP_Toolset.php
@@ -83,6 +83,7 @@ class WP_Toolset {
 	/**
 	 * Decorate any term descriptor to include the full term and taxonomy objects
 	 *
+	 * @param array $descriptor
 	 * @return mixed
 	 */
 	public function wildcard_term_descriptor_to_full_term_descriptor( $descriptor ) {

--- a/core/Widget/Widget.php
+++ b/core/Widget/Widget.php
@@ -3,7 +3,6 @@
 namespace Carbon_Fields\Widget;
 
 use Carbon_Fields\Helper\Helper;
-use Carbon_Fields\Field\Field;
 use Carbon_Fields\Container\Container;
 use Carbon_Fields\Datastore\Datastore;
 use Carbon_Fields\Exception\Incorrect_Syntax_Exception;
@@ -17,7 +16,7 @@ abstract class Widget extends \WP_Widget {
 	/**
 	 * Widget Datastore
 	 *
-	 * @var Widget_Datastore
+	 * @var \Carbon_Fields\Datastore\Widget_Datastore
 	 */
 	protected $datastore;
 
@@ -190,7 +189,7 @@ abstract class Widget extends \WP_Widget {
 	 */
 	public function add_fields( $fields ) {
 		foreach ( $fields as $field ) {
-			if ( ! is_a( $field, 'Carbon_Fields\\Field\\Field' ) ) {
+			if ( ! ( $field instanceof \Carbon_Fields\Field\Field ) ) {
 				Incorrect_Syntax_Exception::raise( 'Object must be of type Carbon_Fields\\Field\\Field' );
 				return;
 			}

--- a/core/functions.php
+++ b/core/functions.php
@@ -17,7 +17,7 @@ if ( ! function_exists( 'carbon_get' ) ) {
 
 if ( ! function_exists( 'carbon_set' ) ) {
 	function carbon_set( $object_id, $name, $value, $container_type, $container_id = '' ) {
-		return Helper::set_value( $object_id, $container_type, $container_id, $name, $value );
+		Helper::set_value( $object_id, $container_type, $container_id, $name, $value );
 	}
 }
 
@@ -35,7 +35,7 @@ if ( ! function_exists( 'carbon_get_post_meta' ) ) {
 
 if ( ! function_exists( 'carbon_set_post_meta' ) ) {
 	function carbon_set_post_meta( $id, $name, $value, $container_id = '' ) {
-		return Helper::set_post_meta( $id, $name, $value, $container_id );
+		Helper::set_post_meta( $id, $name, $value, $container_id );
 	}
 }
 
@@ -47,7 +47,7 @@ if ( ! function_exists( 'carbon_get_theme_option' ) ) {
 
 if ( ! function_exists( 'carbon_set_theme_option' ) ) {
 	function carbon_set_theme_option( $name, $value, $container_id = '' ) {
-		return Helper::set_theme_option( $name, $value, $container_id );
+		Helper::set_theme_option( $name, $value, $container_id );
 	}
 }
 
@@ -65,7 +65,7 @@ if ( ! function_exists( 'carbon_get_network_option' ) ) {
 
 if ( ! function_exists( 'carbon_set_network_option' ) ) {
 	function carbon_set_network_option( $id, $name, $value, $container_id = '' ) {
-		return Helper::set_network_option( $id, $name, $value, $container_id );
+		Helper::set_network_option( $id, $name, $value, $container_id );
 	}
 }
 
@@ -77,7 +77,7 @@ if ( ! function_exists( 'carbon_get_term_meta' ) ) {
 
 if ( ! function_exists( 'carbon_set_term_meta' ) ) {
 	function carbon_set_term_meta( $id, $name, $value, $container_id = '' ) {
-		return Helper::set_term_meta( $id, $name, $value, $container_id );
+		Helper::set_term_meta( $id, $name, $value, $container_id );
 	}
 }
 
@@ -89,7 +89,7 @@ if ( ! function_exists( 'carbon_get_user_meta' ) ) {
 
 if ( ! function_exists( 'carbon_set_user_meta' ) ) {
 	function carbon_set_user_meta( $id, $name, $value, $container_id = '' ) {
-		return Helper::set_user_meta( $id, $name, $value, $container_id );
+		Helper::set_user_meta( $id, $name, $value, $container_id );
 	}
 }
 
@@ -101,7 +101,7 @@ if ( ! function_exists( 'carbon_get_comment_meta' ) ) {
 
 if ( ! function_exists( 'carbon_set_comment_meta' ) ) {
 	function carbon_set_comment_meta( $id, $name, $value, $container_id = '' ) {
-		return Helper::set_comment_meta( $id, $name, $value, $container_id );
+		Helper::set_comment_meta( $id, $name, $value, $container_id );
 	}
 }
 
@@ -113,7 +113,7 @@ if ( ! function_exists( 'carbon_get_nav_menu_item_meta' ) ) {
 
 if ( ! function_exists( 'carbon_set_nav_menu_item_meta' ) ) {
 	function carbon_set_nav_menu_item_meta( $id, $name, $value, $container_id = '' ) {
-		return Helper::set_nav_menu_item_meta( $id, $name, $value, $container_id );
+		Helper::set_nav_menu_item_meta( $id, $name, $value, $container_id );
 	}
 }
 


### PR DESCRIPTION
+ `__callStatic()` and PhpDocs for improved PhpStorm auto-completion:

![autocomplete-field](https://user-images.githubusercontent.com/812192/58138329-a1095400-7c03-11e9-8be9-77c53b0ccb4d.png)

![autocomplete-container](https://user-images.githubusercontent.com/812192/58138337-a4044480-7c03-11e9-8e67-4b9b97ca3464.png)

+ Fix: `\Carbon_Fields\Field\Association_Field::format_term_option` was passing object instead of ID

+ Fix: `remove_filter` and `remove_action` only take 3 parameters

+ Fix: `Fulfillable_Collection::propagate_condition_type_list` foreach fulfillable

+ PhpDocs fixed/improved

+ `instanceof` available since PHP 5.0. It's faster (micro optimization) but mostly it helps the IDE auto-complete

+ Don't return void values

+ `.phpstorm.meta.php` for IoC (factories)