### PR TITLE
Add style fixes for association field

### DIFF
--- a/packages/core/fields/association/style.scss
+++ b/packages/core/fields/association/style.scss
@@ -2,6 +2,16 @@
    Association
    ========================================================================== */
 
+.container-carbon_fields_container_word_settings {
+	min-width: 0;
+	max-width: 100%;
+	width: 100%;
+}
+
+.cf-container .cf-field {
+	max-width: 100%;
+}
+
 .cf-association__bar {
 	position: relative;
 	z-index: 1;
@@ -74,6 +84,12 @@
 	width: 50%;
 	max-height: 160px;
 	overflow-y: auto;
+
+	&.ui-sortable .cf-association__option-title {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
 }
 
 .cf-association__option {


### PR DESCRIPTION
The issue was that when introduced with a long title in the Association Field - the field was expanding beyond it's parent width.

I've added styles to the `<fieldset>` wrapper of the fields and set a max-width for the Association Fields container.
Also there are added styles for the chosen field on the right. 