### PR TITLE
#734 Avoid Media Gallery crash with images /wo thumbnail

### DIFF
--- a/packages/core/fields/media-gallery/index.js
+++ b/packages/core/fields/media-gallery/index.js
@@ -87,6 +87,23 @@ class MediaGalleryField extends Component {
 
 		onChange( id, attachments );
 	}
+	
+	/**
+	 * Returns an URL to the attachment's thumbnail.
+	 *
+	 * @return {string}
+	 */
+	getAttachmentThumb( attachment ) {
+		if ( attachment.sizes ) {
+			const size = attachment.sizes.thumbnail || attachment.sizes.full;
+
+			if ( size ) {
+				return size.url;
+			}
+		}
+
+		return attachment.url;
+	}
 
 	/**
 	 * Render the component.
@@ -152,7 +169,7 @@ class MediaGalleryField extends Component {
 																	? (
 																		<img
 																			className="cf-media-gallery__item-thumb"
-																			src={ attachment.sizes.thumbnail.url }
+																			src={ this.getAttachmentThumb( attachment ) }
 																		/>
 																	)
 																	: (


### PR DESCRIPTION
First of all, I'm not a React developer, and I may not have followed the usual workflow.   
I didn't not found any built files in your repo, so I think It's okay.