### PR TITLE
Patch to rest_no_route error on attachment ajax call for file field with plain permalinks

### DIFF
--- a/packages/core/fields/file/index.js
+++ b/packages/core/fields/file/index.js
@@ -32,9 +32,14 @@ class FileField extends Component {
 		if ( value ) {
 			// TODO: Refactor this to use `@wordpress/api-fetch` package.
 			apiFetch(
-				`${ window.wpApiSettings.root }carbon-fields/v1/attachment/?type=${ field.value_type }&value=${ value }`,
-				'get'
-			).then( this.handleFileDataChange );
+				`${ window.wpApiSettings.root }carbon-fields/v1/attachment/`,
+				'get',
+				{
+					type: field.value_type,
+					value: value
+				}
+			)
+				.then( this.handleFileDataChange );
 		}
 	}
 


### PR DESCRIPTION
Making this field behave more like the association field and use the apiFetch data parameter in order to fix a rest_no_route error when for attachment ajax call when using plain permalinks structure. More info here.

https://community.carbonfields.net/t/attachment-ajax-call-fails-rest-no-route-for-image-field/154