### PR TITLE
Update Nav_Menu_Item_Edit_Walker.php

### DIFF
--- a/core/Walker/Nav_Menu_Item_Edit_Walker.php
+++ b/core/Walker/Nav_Menu_Item_Edit_Walker.php
@@ -26,6 +26,7 @@ class Nav_Menu_Item_Edit_Walker extends \Walker_Nav_Menu_Edit {
 		// Generates the HTML
 		ob_start();
 		do_action( 'carbon_fields_print_nav_menu_item_container_fields', $item, $output, $depth, $args, $id );
+		do_action( 'wp_nav_menu_item_custom_fields', $item->ID, $item, $depth, $args, $id );
 		echo $flag;
 		$fields = ob_get_clean();
 


### PR DESCRIPTION
Added missing menu item action
http://hookr.io/actions/wp_nav_menu_item_custom_fields/
Now CF use custom Walker to render Menu items .
Adding new field to menu item removes all fields added by filter **wp_nav_menu_item_custom_fields**
It affects both, manually created custom field and fields added by ACF
This commit fix that.