### PR TITLE
Allow media_gallery field to save any number of attachments

### DIFF
--- a/packages/core/utils/fetch-attachments-data.js
+++ b/packages/core/utils/fetch-attachments-data.js
@@ -10,7 +10,8 @@ export default ( attachments ) => {
 			data: {
 				action: 'query-attachments',
 				query: {
-					post__in: attachments
+					post__in: attachments,
+					posts_per_page: attachments.length
 				}
 			}
 		} );


### PR DESCRIPTION
Currently, the media_gallery field can only save **X** attachments.
**X** being the number set in Settings -> Reading -> posts_per_page
![image](https://user-images.githubusercontent.com/15157695/66699729-e1bc5380-ecf1-11e9-8d9b-c9faac2b1357.png)

There are a few open issues that mention this:
https://github.com/htmlburger/carbon-fields/issues/665
https://github.com/htmlburger/carbon-fields/issues/688

This commit allows the media_gallery field to save any number of attachments.

**Steps to reproduce the problem**:
1. Go to Settings -> Reading
2. Set "Blog pages show at most" to **X** (any number)
3. Add more than **X** images to a media_gallery field and save changes
4. Only the first **X** images would be saved.