### PR TITLE
Fix disabled 'Save' button when on widget init

### DIFF
--- a/packages/metaboxes/containers/widget/index.js
+++ b/packages/metaboxes/containers/widget/index.js
@@ -45,7 +45,7 @@ function handler( props ) {
 				// trigger change when the expand button is clicked
 				$carbonContainer
 					.closest( '.widget' )
-					.find( '.widget-action' )
+					.find( '.widget-top' )
 					.on( 'click', () => {
 						setTimeout( () => {
 							$carbonContainer.trigger( 'change' );


### PR DESCRIPTION
There is a `trigger( 'change' );` when the arrow of a widget title is clicked. But if a user clicks on anywhere else of the title section ( which also opens the widget ), the event is not triggered and the 'Save' button stays disabled. This modification fixes the problem.