### PR TITLE
Fix post revision meta saving check when post_template conditional is…

### DIFF
--- a/core/Container/Condition/Post_Template_Condition.php
+++ b/core/Container/Condition/Post_Template_Condition.php
@@ -20,6 +20,12 @@ class Post_Template_Condition extends Condition {
 		$is_page_for_posts = intval( $post_id ) === intval( get_option( 'page_for_posts' ) );
 
 		$post_template = get_post_meta( $post_id, '_wp_page_template', true );
+
+		// If this is a revision, there may not be a _wp_page_template record, so look up the parent template.
+		if ( ! $post_template && 'revision' === get_post_type( $post_id ) ) {
+			$post_template = get_post_meta( $environment['post']->post_parent, '_wp_page_template', true );
+		}
+
 		if ( ! $post_template || $is_page_for_posts ) {
 			$post_template = 'default';
 		}


### PR DESCRIPTION
… set.

Post_Template_Condition.php checks for existence of _wp_page_template in post_meta before saving. When the post is a revision there may not be a post_meta entry for _wp_page_template, so we need to check the parent post to ensure revision metadata is saved.

Fixes #829