### PR TITLE
add carbon_fields_get_assets_context filter to allow forcing of context

### DIFF
--- a/core/Loader/Loader.php
+++ b/core/Loader/Loader.php
@@ -140,7 +140,7 @@ class Loader {
 	 * @return string
 	 */
 	protected function get_assets_context() {
-		return wp_script_is( 'wp-element' ) ? 'gutenberg' : 'classic';
+		return apply_filters( 'carbon_fields_get_assets_context', wp_script_is( 'wp-element' ) ? 'gutenberg' : 'classic' );
 	}
 
 	/**


### PR DESCRIPTION
Current carbonfields checks if wp-element is equeued to determine which context to load (gutenberg/classic) Plugins can break this lookup by enqueueing wp-element on their own for example the Yoast plugin. This filter allows forcing of asset context in that situation.

Fix #857