### PR TITLE
Fix a typo that has been present since at least 2.2.0

### DIFF
--- a/core/Provider/Container_Condition_Provider.php
+++ b/core/Provider/Container_Condition_Provider.php
@@ -132,7 +132,7 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 			$condition->set_comparers( $ioc['container_condition_comparer_collections']['array'] );
 			return $condition;
 		} );
-		$cc_ioc['user_capabiltiy'] = $cc_ioc->factory( function() use ( $ioc ) {
+		$cc_ioc['user_capability'] = $cc_ioc->factory( function() use ( $ioc ) {
 			$condition = new \Carbon_Fields\Container\Condition\User_Capability_Condition();
 			$condition->set_comparers( array(
 				// Only support the custom comparer as this condition has its own comparison methods


### PR DESCRIPTION
the condition user_capability does not work as there is a typo in the factories list;

user_capabiltiy

instead of 

user_capability

This PR fixes this for the most recent version.

If at all possible, please back-port to v2.2.x.