### PR TITLE
 Add jquery.1 as a dependancy to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "callbag-take-until": "^3.0.0",
     "classnames": "^2.2.6",
     "immer": "^1.7.4",
+    "jquery.1": "^1.0.0",
     "lodash": "^4.17.13",
     "nanoid": "^2.0.0",
     "observe-resize": "^1.1.3",


### PR DESCRIPTION
Following the instructions in CONTRIBUTING.md I get multiple errors from npm run build

Module not found: Error: Can't resolve 'jquery' ...

Adding jquery.1 to package.json resolves this error.