### PR TITLE
Handling multibyte filenames for the "image" type carbon field

### DIFF
--- a/core/Helper/Helper.php
+++ b/core/Helper/Helper.php
@@ -509,7 +509,7 @@ class Helper {
 		 */
 		$url = apply_filters( 'carbon_fields_attachment_id_base_url', $url );
 
-		$filename = static::mb_basename( $url );
+		$filename = wp_basename( $url );
 
 		if ( strpos( $url, $dir['baseurl'] . '/' ) !== false ) {
 			$query_args = array(
@@ -530,7 +530,7 @@ class Helper {
 			if ( $query->have_posts() ) {
 				foreach ( $query->posts as $post_id ) {
 					$meta                = wp_get_attachment_metadata( $post_id );
-					$original_file       = static::mb_basename( $meta['file'] );
+					$original_file       = wp_basename( $meta['file'] );
 					$cropped_image_files = wp_list_pluck( $meta['sizes'], 'file' );
 
 					if ( $original_file === $filename || in_array( $filename, $cropped_image_files ) ) {
@@ -599,7 +599,7 @@ class Helper {
 
 		$attachment_metadata['id']        = intval( $id );
 		$attachment_metadata['file_url']  = is_numeric( $id ) ? wp_get_attachment_url( $id ) : $id;
-		$attachment_metadata['file_name'] = static::mb_basename( $attachment_metadata['file_url'] );
+		$attachment_metadata['file_name'] = wp_basename( $attachment_metadata['file_url'] );
 		$attachment_metadata['filetype']  = wp_check_filetype( $attachment_metadata['file_url'] );
 		$attachment_metadata['file_type'] = preg_replace( '~\/.+$~', '', $attachment_metadata['filetype']['type'] ); // image, video, etc..
 
@@ -704,19 +704,5 @@ class Helper {
 		}
 
 		return $sidebars;
-	}
-
-	/**
-	 * Return multibyte basename of a file 
-	 * @param string $path                 The path of a file
-	 * @return string
-	 */
-	public static function mb_basename($path) {
-		if (preg_match('@^.*[\\\\/]([^\\\\/]+)$@s', $path, $matches)) {
-				return $matches[1];
-		} else if (preg_match('@^([^\\\\/]+)$@s', $path, $matches)) {
-				return $matches[1];
-		}
-		return '';
 	}
 }

--- a/core/Helper/Helper.php
+++ b/core/Helper/Helper.php
@@ -509,7 +509,7 @@ class Helper {
 		 */
 		$url = apply_filters( 'carbon_fields_attachment_id_base_url', $url );
 
-		$filename = basename( $url );
+		$filename = static::mb_basename( $url );
 
 		if ( strpos( $url, $dir['baseurl'] . '/' ) !== false ) {
 			$query_args = array(
@@ -530,7 +530,7 @@ class Helper {
 			if ( $query->have_posts() ) {
 				foreach ( $query->posts as $post_id ) {
 					$meta                = wp_get_attachment_metadata( $post_id );
-					$original_file       = basename( $meta['file'] );
+					$original_file       = static::mb_basename( $meta['file'] );
 					$cropped_image_files = wp_list_pluck( $meta['sizes'], 'file' );
 
 					if ( $original_file === $filename || in_array( $filename, $cropped_image_files ) ) {
@@ -599,7 +599,7 @@ class Helper {
 
 		$attachment_metadata['id']        = intval( $id );
 		$attachment_metadata['file_url']  = is_numeric( $id ) ? wp_get_attachment_url( $id ) : $id;
-		$attachment_metadata['file_name'] = basename( $attachment_metadata['file_url'] );
+		$attachment_metadata['file_name'] = static::mb_basename( $attachment_metadata['file_url'] );
 		$attachment_metadata['filetype']  = wp_check_filetype( $attachment_metadata['file_url'] );
 		$attachment_metadata['file_type'] = preg_replace( '~\/.+$~', '', $attachment_metadata['filetype']['type'] ); // image, video, etc..
 
@@ -704,5 +704,19 @@ class Helper {
 		}
 
 		return $sidebars;
+	}
+
+	/**
+	 * Return multibyte basename of a file 
+	 * @param string $path                 The path of a file
+	 * @return string
+	 */
+	public static function mb_basename($path) {
+		if (preg_match('@^.*[\\\\/]([^\\\\/]+)$@s', $path, $matches)) {
+				return $matches[1];
+		} else if (preg_match('@^([^\\\\/]+)$@s', $path, $matches)) {
+				return $matches[1];
+		}
+		return '';
 	}
 }


### PR DESCRIPTION
Related to this issue:
https://github.com/htmlburger/carbon-fields/issues/949

Replacing calls to basename() (default PHP function) to mb_basename() (as defined [here](https://www.php.net/manual/en/function.basename.php#121405)) inside core/Helper/Helper.php

basename() doesn't handle mutibyte characters.
