### PR TITLE
Update documentation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See [Quickstart](https://github.com/htmlburger/carbon-fields-docs/tree/master/do
 ### Documentation & Other Resources
 
 * [Website](http://carbonfields.net/)
-* [Documentation (website)](http://carbonfields.net/docs/)
+* [Documentation (website)](https://docs.carbonfields.net/)
 * [Documentation (GitHub)](https://github.com/htmlburger/carbon-fields-docs)
 * [FAQ](http://carbonfields.net/faq/)
 * [Support](http://carbonfields.net/support/)


### PR DESCRIPTION
I just discovered Carbon Fields coming from CMB2 and my mind is blown :sweat_smile: Even more so, after noticing I was reading the v2 docs and v3 was out already. This PR updates the `Documentation (website)` link in the readme to the v3 docs (http://carbonfields.net/docs/ -> https://docs.carbonfields.net/).