### PR TITLE
Make it possible to register custom script in new Block

### DIFF
--- a/core/Container/Block_Container.php
+++ b/core/Container/Block_Container.php
@@ -242,6 +242,43 @@ class Block_Container extends Container {
 	}
 
 	/**
+	 * Set a script handle.
+	 *
+	 * @param  string $key
+	 * @param  string $handle
+	 * @return Block_Container
+	 */
+	protected function set_script_handle( $key, $handle ) {
+		if ( ! wp_script_is( $handle, "enqueued" ) && ! wp_script_is( $handle, "registered" ) ) {
+			throw new \Exception( __( "script '$handle' is not enqueued or registered.", 'crb' ) );
+		}
+
+		$this->settings[ $key ] = $handle;
+
+		return $this;
+	}
+
+	/**
+	 * Set the script of the block type.
+	 *
+	 * @param  string $handle
+	 * @return Block_Container
+	 */
+	public function set_script( $handle ) {
+		return $this->set_script_handle( 'script', $handle );
+	}
+
+	/**
+	 * Set the editor script of the block type.
+	 *
+	 * @param  string $handle
+	 * @return Block_Container
+	 */
+	public function set_editor_script( $handle ) {
+		return $this->set_script_handle( 'editor_script', $handle );
+	}
+
+	/**
 	 * Set whether the preview mode is available for the block type.
 	 *
 	 * @param  boolean $preview
@@ -443,6 +480,8 @@ class Block_Container extends Container {
 
 		$style = isset( $this->settings[ 'style' ] ) ? $this->settings[ 'style' ] : null;
 		$editor_style = isset( $this->settings[ 'editor_style' ] ) ? $this->settings[ 'editor_style' ] : null;
+		$script = isset( $this->settings[ 'script' ] ) ? $this->settings[ 'script' ] : null;
+		$editor_script = isset( $this->settings[ 'editor_script' ] ) ? $this->settings[ 'editor_script' ] : null;
 		$attributes = array_reduce( $this->get_fields(), function( $attributes, $field ) {
 			$attributes[ 'data' ][ 'default' ][ $field->get_base_name() ] = $field->get_default_value();
 
@@ -457,6 +496,8 @@ class Block_Container extends Container {
 		register_block_type( $this->get_block_type_name(), array(
 			'style' => $style,
 			'editor_style' => $editor_style,
+			'script' => $script,
+			'editor_script' => $editor_script,
 			'attributes' => $attributes,
 			'render_callback' => array( $this, 'render_block' ),
 		) );


### PR DESCRIPTION
This pull request makes it possible to set a custom script for the frontend and backend (editor) for the block.

Followed the same exact patterns used by the set_style methods.

How to use it:

```php
	wp_register_script('shiny_block', get_template_directory_uri().'/assets/js/block-test.js', [], false, true);
	wp_register_script('shiny_block_editor', get_template_directory_uri().'/assets/js/block-test-editor.js', [], false, true);

	Block::make( __( 'My Shiny Gutenberg Block 2' ) )
		->set_script('shiny_block')
		->set_editor_script('shiny_block_editor')
		->set_render_callback( function ( $fields, $attributes, $inner_blocks ) {
			?>
			<div class="block">
				....
			</div><!-- /.block -->	
			<?php
		} );
```

Don't know if it's a bug or simply by design. But in the editor interface it runs both scripts.

This attend partially to a feature requested in #664 .