### PR TITLE
Switch to 'block_categories_all'

### DIFF
--- a/core/Container/Block_Container.php
+++ b/core/Container/Block_Container.php
@@ -122,7 +122,7 @@ class Block_Container extends Container {
 	 * {@inheritDoc}
 	 */
 	public function attach() {
-		add_filter( 'block_categories', array( $this, 'attach_block_category' ), 10, 2 );
+		add_filter( 'block_categories_all', array( $this, 'attach_block_category' ), 10, 2 );
 
 		$this->register_block();
 	}


### PR DESCRIPTION
Replace deprecated 'block_categories' with 'block_categories_all' which was [introduced](https://core.trac.wordpress.org/ticket/52920) in WordPress 5.8.