### PR TITLE
Show only published posts in the initial field options

### DIFF
--- a/core/Field/Association_Field.php
+++ b/core/Field/Association_Field.php
@@ -441,6 +441,7 @@ class Association_Field extends Field {
 			'fields'           => 'ids',
 			'suppress_filters' => false,
 			's'                => $search_term,
+			'post_status'      => 'publish',
 		) );
 
 		add_filter( 'posts_fields_request', array( $this, 'get_post_options_sql_select_clause' ) );


### PR DESCRIPTION
Currently, the initial Association field options are not filtered by `post_status`.
This commit filters the posts to ensure that only published entries are displayed.

**Steps to reproduce the problem:**
1. Create an Association field
2. Save a post with the Draft status
3. Visit the Association field's UI
4. It will show the unpublished post in the list of available entries