### PR TITLE
Updates Container to match interface return types

### DIFF
--- a/core/Pimple/Container.php
+++ b/core/Pimple/Container.php
@@ -71,7 +71,7 @@ class Container implements \ArrayAccess
      *
      * @throws \RuntimeException Prevent override of a frozen service
      */
-    public function offsetSet($id, $value)
+    public function offsetSet($id, $value): void
     {
         if (isset($this->frozen[$id])) {
             throw new \RuntimeException(sprintf('Cannot override frozen service "%s".', $id));
@@ -90,7 +90,7 @@ class Container implements \ArrayAccess
      *
      * @throws \InvalidArgumentException if the identifier is not defined
      */
-    public function offsetGet($id)
+    public function offsetGet($id): mixed
     {
         if (!isset($this->keys[$id])) {
             throw new \InvalidArgumentException(sprintf('Identifier "%s" is not defined.', $id));
@@ -125,7 +125,7 @@ class Container implements \ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($id)
+    public function offsetExists($id): bool
     {
         return isset($this->keys[$id]);
     }
@@ -135,7 +135,7 @@ class Container implements \ArrayAccess
      *
      * @param string $id The unique identifier for the parameter or object
      */
-    public function offsetUnset($id)
+    public function offsetUnset($id): void
     {
         if (isset($this->keys[$id])) {
             if (is_object($this->values[$id])) {


### PR DESCRIPTION
PHP 8.1 throws deprecation warnings if implementations of `ArrayAccess` do not match the interface's return types. This change eliminates those warnings.

Fixes #1079

Simpler than #1125 - though perhaps there are reasons to go the more elaborate route.