### PR TITLE
[PHP 8.3] Fix `get_class()` and `get_parent_class()` deprecations

### DIFF
--- a/core/Block.php
+++ b/core/Block.php
@@ -11,6 +11,6 @@ class Block extends Container {
 	 * {@inheritDoc}
 	 */
 	public static function make() {
-		return call_user_func_array( array( get_parent_class(), 'make' ), array_merge( array( 'block' ), func_get_args() ) );
+		return call_user_func_array( array( parent::class, 'make' ), array_merge( array( 'block' ), func_get_args() ) );
 	}
 }

--- a/core/Container.php
+++ b/core/Container.php
@@ -33,7 +33,7 @@ class Container {
 	 * @return \Carbon_Fields\Container\Container
 	 */
 	public static function make() {
-		return call_user_func_array( array( get_class(), 'factory' ), func_get_args() );
+		return call_user_func_array( array( __CLASS__, 'factory' ), func_get_args() );
 	}
 
 	/**
@@ -46,9 +46,9 @@ class Container {
 		if ( strpos( $method, 'make_' ) === 0 ) {
 			$raw_type = substr_replace( $method, '', 0, 5 );
 			array_unshift( $arguments, $raw_type );
-			return call_user_func_array( array( get_class(), 'factory' ), $arguments );
+			return call_user_func_array( array( __CLASS__, 'factory' ), $arguments );
 		} else {
-			trigger_error( sprintf( 'Call to undefined function: %s::%s().', get_class(), $method ), E_USER_ERROR );
+			trigger_error( sprintf( 'Call to undefined function: %s::%s().', __CLASS__, $method ), E_USER_ERROR );
 		}
 	}
 }

--- a/core/Container/Container.php
+++ b/core/Container/Container.php
@@ -223,7 +223,7 @@ abstract class Container implements Datastore_Holder_Interface {
 	 * @return Container
 	 */
 	public static function make() {
-		return call_user_func_array( array( get_class(), 'factory' ), func_get_args() );
+		return call_user_func_array( array( __CLASS__, 'factory' ), func_get_args() );
 	}
 
 	/**

--- a/core/Container/Nav_Menu_Item_Container.php
+++ b/core/Container/Nav_Menu_Item_Container.php
@@ -37,7 +37,7 @@ class Nav_Menu_Item_Container extends Container {
 		}
 
 		// Register the custom edit walker only once
-		$callable = array( get_class(), 'edit_walker' );
+		$callable = array( __CLASS__, 'edit_walker' );
 		if ( ! has_filter( 'wp_edit_nav_menu_walker', $callable ) ) {
 			add_filter( 'wp_edit_nav_menu_walker', $callable, 10, 2 );
 		}

--- a/core/Container/Theme_Options_Container.php
+++ b/core/Container/Theme_Options_Container.php
@@ -251,7 +251,7 @@ class Theme_Options_Container extends Container {
 	 * @return Container                      $this
 	 */
 	public function set_page_parent( $parent ) {
-		if ( is_a( $parent, get_class() ) ) {
+		if ( is_a( $parent, __CLASS__ ) ) {
 			$this->settings['parent'] = $parent->get_page_file();
 			return $this;
 		}

--- a/core/Datastore/Datastore.php
+++ b/core/Datastore/Datastore.php
@@ -76,6 +76,6 @@ abstract class Datastore implements Datastore_Interface {
 	 * @return Datastore_Interface
 	 */
 	public static function make() {
-		return call_user_func_array( array( get_class(), 'factory' ), func_get_args() );
+		return call_user_func_array( array( __CLASS__, 'factory' ), func_get_args() );
 	}
 }

--- a/core/Field.php
+++ b/core/Field.php
@@ -54,7 +54,7 @@ class Field {
 	 * @return \Carbon_Fields\Field\Field
 	 */
 	public static function make() {
-		return call_user_func_array( array( get_class(), 'factory' ), func_get_args() );
+		return call_user_func_array( array( __CLASS__, 'factory' ), func_get_args() );
 	}
 
 	/**
@@ -67,9 +67,9 @@ class Field {
 		if ( strpos( $method, 'make_' ) === 0 ) {
 			$raw_type = substr_replace( $method, '', 0, 5 );
 			array_unshift( $arguments, $raw_type );
-			return call_user_func_array( array( get_class(), 'factory' ), $arguments );
+			return call_user_func_array( array( __CLASS__, 'factory' ), $arguments );
 		} else {
-			trigger_error( sprintf( 'Call to undefined function: %s::%s().', get_class(), $method ), E_USER_ERROR );
+			trigger_error( sprintf( 'Call to undefined function: %s::%s().', __CLASS__, $method ), E_USER_ERROR );
 		}
 	}
 }

--- a/core/Field/Field.php
+++ b/core/Field/Field.php
@@ -249,7 +249,7 @@ class Field implements Datastore_Holder_Interface {
 	 * @return Field
 	 */
 	public static function make() {
-		return call_user_func_array( array( get_class(), 'factory' ), func_get_args() );
+		return call_user_func_array( array( __CLASS__, 'factory' ), func_get_args() );
 	}
 
 	/**
@@ -293,8 +293,8 @@ class Field implements Datastore_Holder_Interface {
 	public function activate() {
 		$this->admin_init();
 
-		add_action( 'admin_print_footer_scripts', array( get_class(), 'admin_hook_scripts' ), 5 );
-		add_action( 'admin_print_footer_scripts', array( get_class(), 'admin_hook_styles' ), 5 );
+		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'admin_hook_scripts' ), 5 );
+		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'admin_hook_styles' ), 5 );
 		static::activate_field_type( get_class( $this ) );
 
 		do_action( 'carbon_fields_field_activated', $this );


### PR DESCRIPTION
In PHP 8.3, [calling `get_class()` and `get_parent_class()` functions without arguments is deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated).

This fixes them with identical alternatives that do not cause the deprecation notice.

References:
 - [PHP RFC: Deprecate functions with overloaded signatures](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 - [PHP 8.3: get_class() and get_parent_class() function calls without arguments deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated)