### PR TITLE
Test data.documentElement is actually present

### DIFF
--- a/packages/metaboxes/containers/term-meta/index.js
+++ b/packages/metaboxes/containers/term-meta/index.js
@@ -32,6 +32,7 @@ function aperture() {
 			return options.data
 				&& options.data.indexOf( 'carbon_fields_container' ) > -1
 				&& options.data.indexOf( 'add-tag' ) > -1
+				&& data.documentElement
 				&& ! data.documentElement.querySelector( 'wp_error' );
 		} )
 	);


### PR DESCRIPTION
We were running into the issue that Carbon-Fields would interfere with an AJAX call from another plugin on the edit-tags page. The added condition makes sure that the last condition in the filter callback does not raise an exception during the test.