### PR TITLE
Update Container.php to allow the addition of notifications

### DIFF
--- a/core/Container/Container.php
+++ b/core/Container/Container.php
@@ -786,6 +786,15 @@ abstract class Container implements Datastore_Holder_Interface {
 	}
 
 	/**
+ 	 * Adds a notification to be shown.
+     *
+	 * @param string $notification
+  	 */
+	public function add_notification ($notification) {
+        $this->notifications[] = $notification;
+    }
+
+	/**
 	 * Returns an array that holds the container data, suitable for JSON representation.
 	 *
 	 * @param bool $load  Should the value be loaded from the database or use the value from the current instance.


### PR DESCRIPTION
The library has a beautiful notification system, but there is no mechanism to add notifications from outside of the class if needed. The add_notification function will give this possibility. I have tested that on a theme_options container, not sure what effect notifications have on other container types. Maybe the same can be done for error messages.