### PR TITLE
Feature 464. Add Post Status support in post meta conditions

### DIFF
--- a/core/Container/Condition/Post_Status_Condition.php
+++ b/core/Container/Condition/Post_Status_Condition.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Carbon_Fields\Container\Condition;
+
+/**
+ * Check if post has specified status
+ */
+class Post_Status_Condition extends Condition
+{
+
+	/**
+	 * Check if the condition is fulfilled
+	 *
+	 * @param  array $environment
+	 * @return bool
+	 */
+	public function is_fulfilled($environment)
+	{
+		$post_status = $environment['post_status'];
+		return $this->compare(
+			$post_status,
+			$this->get_comparison_operator(),
+			$this->get_value()
+		);
+	}
+}

--- a/core/Provider/Container_Condition_Provider.php
+++ b/core/Provider/Container_Condition_Provider.php
@@ -7,18 +7,20 @@ use Carbon_Fields\Pimple\ServiceProviderInterface;
 use Carbon_Fields\Container\Condition\Factory as ConditionFactory;
 use Carbon_Fields\Container\Fulfillable\Fulfillable_Collection;
 
-class Container_Condition_Provider implements ServiceProviderInterface {
+class Container_Condition_Provider implements ServiceProviderInterface
+{
 
 	/**
 	 * Install dependencies in IoC container
 	 *
 	 * @param  PimpleContainer $ioc
 	 */
-	public function register( PimpleContainer $ioc ) {
-		$this->install_conditions( $ioc );
-		$this->install_comparers( $ioc );
-		$this->install_translators( $ioc );
-		$this->install_container_conditions( $ioc );
+	public function register(PimpleContainer $ioc)
+	{
+		$this->install_conditions($ioc);
+		$this->install_comparers($ioc);
+		$this->install_translators($ioc);
+		$this->install_container_conditions($ioc);
 	}
 
 	/**
@@ -26,145 +28,151 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 *
 	 * @param  PimpleContainer $ioc
 	 */
-	protected function install_conditions( $ioc ) {
-		$ioc['container_condition_factory'] = function( $ioc ) {
-			return new ConditionFactory( $ioc['container_conditions'] );
+	protected function install_conditions($ioc)
+	{
+		$ioc['container_condition_factory'] = function ($ioc) {
+			return new ConditionFactory($ioc['container_conditions']);
 		};
 
-		$ioc['container_condition_fulfillable_collection'] = $ioc->factory( function( $ioc ) {
-			return new Fulfillable_Collection( $ioc['container_condition_factory'], $ioc['container_condition_translator_array'] );
-		} );
+		$ioc['container_condition_fulfillable_collection'] = $ioc->factory(function ($ioc) {
+			return new Fulfillable_Collection($ioc['container_condition_factory'], $ioc['container_condition_translator_array']);
+		});
 
-		$ioc['container_conditions'] = function() {
+		$ioc['container_conditions'] = function () {
 			return new PimpleContainer();
 		};
 
 		$cc_ioc = $ioc['container_conditions'];
 
-		$cc_ioc['boolean'] = $cc_ioc->factory( function() use ( $ioc ) {
+		$cc_ioc['boolean'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Boolean_Condition();
-			$condition->set_comparers( array(
+			$condition->set_comparers(array(
 				$ioc['container_condition_comparers']['equality'],
-			) );
+			));
 			return $condition;
-		} );
+		});
 
-		$cc_ioc['post_id'] = $cc_ioc->factory( function() use ( $ioc ) {
+		$cc_ioc['post_id'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Post_ID_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['generic'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
 			return $condition;
-		} );
-		$cc_ioc['post_parent_id'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['post_status'] = $cc_ioc->factory(function () use ($ioc) {
+			$condition = new \Carbon_Fields\Container\Condition\Post_Status_Condition();
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
+			return $condition;
+		});
+		$cc_ioc['post_parent_id'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Post_Parent_ID_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['generic'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
 			return $condition;
-		} );
-		$cc_ioc['post_ancestor_id'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['post_ancestor_id'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Post_Ancestor_ID_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['array'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['array']);
 			return $condition;
-		} );
-		$cc_ioc['post_type'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['post_type'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Post_Type_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['nonscalar'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['nonscalar']);
 			return $condition;
-		} );
-		$cc_ioc['post_format'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['post_format'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Post_Format_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['nonscalar'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['nonscalar']);
 			return $condition;
-		} );
-		$cc_ioc['post_level'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['post_level'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Post_Level_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['generic'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
 			return $condition;
-		} );
-		$cc_ioc['post_template'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['post_template'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Post_Template_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['nonscalar'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['nonscalar']);
 			return $condition;
-		} );
-		$cc_ioc['post_term'] = $cc_ioc->factory( function() use ( $ioc ) {
-			$condition = new \Carbon_Fields\Container\Condition\Post_Term_Condition( $ioc['wp_toolset'] );
-			$condition->set_comparers( array(
+		});
+		$cc_ioc['post_term'] = $cc_ioc->factory(function () use ($ioc) {
+			$condition = new \Carbon_Fields\Container\Condition\Post_Term_Condition($ioc['wp_toolset']);
+			$condition->set_comparers(array(
 				// Only support the custom comparer as this condition has its own comparison methods
 				$ioc['container_condition_comparers']['custom'],
-			) );
+			));
 			return $condition;
-		} );
+		});
 
-		$cc_ioc['term'] = $cc_ioc->factory( function() use ( $ioc ) {
-			$condition = new \Carbon_Fields\Container\Condition\Term_Condition( $ioc['wp_toolset'] );
-			$condition->set_comparers( array(
+		$cc_ioc['term'] = $cc_ioc->factory(function () use ($ioc) {
+			$condition = new \Carbon_Fields\Container\Condition\Term_Condition($ioc['wp_toolset']);
+			$condition->set_comparers(array(
 				// Only support the custom comparer as this condition has its own comparison methods
 				$ioc['container_condition_comparers']['custom'],
-			) );
+			));
 			return $condition;
-		} );
-		$cc_ioc['term_taxonomy'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['term_taxonomy'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Term_Taxonomy_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['nonscalar'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['nonscalar']);
 			return $condition;
-		} );
-		$cc_ioc['term_level'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['term_level'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Term_Level_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['generic'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
 			return $condition;
-		} );
-		$cc_ioc['term_parent'] = $cc_ioc->factory( function() use ( $ioc ) {
-			$condition = new \Carbon_Fields\Container\Condition\Term_Parent_Condition( $ioc['wp_toolset'] );
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['generic'] );
+		});
+		$cc_ioc['term_parent'] = $cc_ioc->factory(function () use ($ioc) {
+			$condition = new \Carbon_Fields\Container\Condition\Term_Parent_Condition($ioc['wp_toolset']);
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
 			return $condition;
-		} );
-		$cc_ioc['term_ancestor'] = $cc_ioc->factory( function() use ( $ioc ) {
-			$condition = new \Carbon_Fields\Container\Condition\Term_Ancestor_Condition( $ioc['wp_toolset'] );
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['array'] );
+		});
+		$cc_ioc['term_ancestor'] = $cc_ioc->factory(function () use ($ioc) {
+			$condition = new \Carbon_Fields\Container\Condition\Term_Ancestor_Condition($ioc['wp_toolset']);
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['array']);
 			return $condition;
-		} );
+		});
 
-		$cc_ioc['user_id'] = $cc_ioc->factory( function() use ( $ioc ) {
+		$cc_ioc['user_id'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\User_ID_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['generic'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
 			return $condition;
-		} );
-		$cc_ioc['user_role'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['user_role'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\User_Role_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['array'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['array']);
 			return $condition;
-		} );
-		$cc_ioc['user_capability'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['user_capability'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\User_Capability_Condition();
-			$condition->set_comparers( array(
+			$condition->set_comparers(array(
 				// Only support the custom comparer as this condition has its own comparison methods
 				$ioc['container_condition_comparers']['custom'],
-			) );
+			));
 			return $condition;
-		} );
+		});
 
-		$cc_ioc['blog_id'] = $cc_ioc->factory( function() use ( $ioc ) {
+		$cc_ioc['blog_id'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Blog_ID_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['generic'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
 			return $condition;
-		} );
+		});
 
-		$cc_ioc['current_user_id'] = $cc_ioc->factory( function() use ( $ioc ) {
+		$cc_ioc['current_user_id'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Current_User_ID_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['generic'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
 			return $condition;
-		} );
-		$cc_ioc['current_user_role'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['current_user_role'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Current_User_Role_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['array'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['array']);
 			return $condition;
-		} );
-		$cc_ioc['current_user_capability'] = $cc_ioc->factory( function() use ( $ioc ) {
+		});
+		$cc_ioc['current_user_capability'] = $cc_ioc->factory(function () use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Current_User_Capability_Condition();
-			$condition->set_comparers( array(
+			$condition->set_comparers(array(
 				// Only support the custom comparer as this condition has its own comparison methods
 				$ioc['container_condition_comparers']['custom'],
-			) );
+			));
 			return $condition;
-		} );
+		});
 	}
 
 	/**
@@ -172,40 +180,41 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 *
 	 * @param  PimpleContainer $ioc
 	 */
-	protected function install_comparers( $ioc ) {
-		$ioc['container_condition_comparers'] = function() {
+	protected function install_comparers($ioc)
+	{
+		$ioc['container_condition_comparers'] = function () {
 			return new PimpleContainer();
 		};
 
-		$ioc['container_condition_comparers']['equality'] = function() {
+		$ioc['container_condition_comparers']['equality'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Equality_Comparer();
 		};
 
-		$ioc['container_condition_comparers']['any_equality'] = function() {
+		$ioc['container_condition_comparers']['any_equality'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Any_Equality_Comparer();
 		};
 
-		$ioc['container_condition_comparers']['contain'] = function() {
+		$ioc['container_condition_comparers']['contain'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Contain_Comparer();
 		};
 
-		$ioc['container_condition_comparers']['any_contain'] = function() {
+		$ioc['container_condition_comparers']['any_contain'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Any_Contain_Comparer();
 		};
 
-		$ioc['container_condition_comparers']['scalar'] = function() {
+		$ioc['container_condition_comparers']['scalar'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Scalar_Comparer();
 		};
 
-		$ioc['container_condition_comparers']['custom'] = function() {
+		$ioc['container_condition_comparers']['custom'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Custom_Comparer();
 		};
 
-		$ioc['container_condition_comparer_collections'] = function() {
+		$ioc['container_condition_comparer_collections'] = function () {
 			return new PimpleContainer();
 		};
 
-		$ioc['container_condition_comparer_collections']['generic'] = function() use ( $ioc ) {
+		$ioc['container_condition_comparer_collections']['generic'] = function () use ($ioc) {
 			return array(
 				$ioc['container_condition_comparers']['equality'],
 				$ioc['container_condition_comparers']['contain'],
@@ -213,14 +222,14 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 				$ioc['container_condition_comparers']['custom'],
 			);
 		};
-		$ioc['container_condition_comparer_collections']['nonscalar'] = function() use ( $ioc ) {
+		$ioc['container_condition_comparer_collections']['nonscalar'] = function () use ($ioc) {
 			return array(
 				$ioc['container_condition_comparers']['equality'],
 				$ioc['container_condition_comparers']['contain'],
 				$ioc['container_condition_comparers']['custom'],
 			);
 		};
-		$ioc['container_condition_comparer_collections']['array'] = function() use ( $ioc ) {
+		$ioc['container_condition_comparer_collections']['array'] = function () use ($ioc) {
 			return array(
 				$ioc['container_condition_comparers']['any_equality'],
 				$ioc['container_condition_comparers']['any_contain'],
@@ -234,13 +243,14 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 *
 	 * @param  PimpleContainer $ioc
 	 */
-	protected static function install_translators( $ioc ) {
-		$ioc['container_condition_translator_array'] = function( $ioc ) {
-			return new \Carbon_Fields\Container\Fulfillable\Translator\Array_Translator( $ioc['container_condition_factory'] );
+	protected static function install_translators($ioc)
+	{
+		$ioc['container_condition_translator_array'] = function ($ioc) {
+			return new \Carbon_Fields\Container\Fulfillable\Translator\Array_Translator($ioc['container_condition_factory']);
 		};
 
-		$ioc['container_condition_translator_json'] = function( $ioc ) {
-			return new \Carbon_Fields\Container\Fulfillable\Translator\Json_Translator( $ioc['container_condition_factory'] );
+		$ioc['container_condition_translator_json'] = function ($ioc) {
+			return new \Carbon_Fields\Container\Fulfillable\Translator\Json_Translator($ioc['container_condition_factory']);
 		};
 	}
 
@@ -249,26 +259,27 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 *
 	 * @param  PimpleContainer $ioc
 	 */
-	protected function install_container_conditions( $ioc ) {
+	protected function install_container_conditions($ioc)
+	{
 		// add current_user_* static condition types to all containers
-		add_filter( 'carbon_fields_container_static_condition_types', function( $condition_types, $container_type, $container ) {
+		add_filter('carbon_fields_container_static_condition_types', function ($condition_types, $container_type, $container) {
 			return array_merge(
 				$condition_types,
-				array( 'current_user_id', 'current_user_role', 'current_user_capability' )
+				array('current_user_id', 'current_user_role', 'current_user_capability')
 			);
-		}, 10, 3 );
+		}, 10, 3);
 
 		// add container-specific conditions
-		add_filter( 'carbon_fields_post_meta_container_static_condition_types', array( $this, 'filter_post_meta_container_static_condition_types' ), 10, 3 );
-		add_filter( 'carbon_fields_post_meta_container_dynamic_condition_types', array( $this, 'filter_post_meta_container_dynamic_condition_types' ), 10, 3 );
+		add_filter('carbon_fields_post_meta_container_static_condition_types', array($this, 'filter_post_meta_container_static_condition_types'), 10, 3);
+		add_filter('carbon_fields_post_meta_container_dynamic_condition_types', array($this, 'filter_post_meta_container_dynamic_condition_types'), 10, 3);
 
-		add_filter( 'carbon_fields_term_meta_container_static_condition_types', array( $this, 'filter_term_meta_container_static_condition_types' ), 10, 3 );
-		add_filter( 'carbon_fields_term_meta_container_dynamic_condition_types', array( $this, 'filter_term_meta_container_dynamic_condition_types' ), 10, 3 );
+		add_filter('carbon_fields_term_meta_container_static_condition_types', array($this, 'filter_term_meta_container_static_condition_types'), 10, 3);
+		add_filter('carbon_fields_term_meta_container_dynamic_condition_types', array($this, 'filter_term_meta_container_dynamic_condition_types'), 10, 3);
 
-		add_filter( 'carbon_fields_user_meta_container_static_condition_types', array( $this, 'filter_user_meta_container_static_condition_types' ), 10, 3 );
-		add_filter( 'carbon_fields_user_meta_container_dynamic_condition_types', array( $this, 'filter_user_meta_container_dynamic_condition_types' ), 10, 3 );
+		add_filter('carbon_fields_user_meta_container_static_condition_types', array($this, 'filter_user_meta_container_static_condition_types'), 10, 3);
+		add_filter('carbon_fields_user_meta_container_dynamic_condition_types', array($this, 'filter_user_meta_container_dynamic_condition_types'), 10, 3);
 
-		add_filter( 'carbon_fields_theme_options_container_static_condition_types', array( $this, 'filter_theme_options_container_static_condition_types' ), 10, 3 );
+		add_filter('carbon_fields_theme_options_container_static_condition_types', array($this, 'filter_theme_options_container_static_condition_types'), 10, 3);
 	}
 
 	/**
@@ -278,10 +289,11 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
-	public function filter_post_meta_container_static_condition_types( $condition_types, $container_type, $container ) {
+	public function filter_post_meta_container_static_condition_types($condition_types, $container_type, $container)
+	{
 		return array_merge(
 			$condition_types,
-			array( 'post_id', 'post_type' )
+			array('post_id', 'post_status', 'post_type')
 		);
 	}
 
@@ -293,10 +305,11 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
-	public function filter_post_meta_container_dynamic_condition_types( $condition_types, $container_type, $container ) {
+	public function filter_post_meta_container_dynamic_condition_types($condition_types, $container_type, $container)
+	{
 		return array_merge(
 			$condition_types,
-			array( 'post_parent_id', 'post_ancestor_id', 'post_format', 'post_level', 'post_template', 'post_term' )
+			array('post_parent_id', 'post_ancestor_id', 'post_format', 'post_level', 'post_template', 'post_term')
 		);
 	}
 
@@ -308,10 +321,11 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
-	public function filter_term_meta_container_static_condition_types( $condition_types, $container_type, $container ) {
+	public function filter_term_meta_container_static_condition_types($condition_types, $container_type, $container)
+	{
 		return array_merge(
 			$condition_types,
-			array( 'term', 'term_taxonomy' )
+			array('term', 'term_taxonomy')
 		);
 	}
 
@@ -323,10 +337,11 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
-	public function filter_term_meta_container_dynamic_condition_types( $condition_types, $container_type, $container ) {
+	public function filter_term_meta_container_dynamic_condition_types($condition_types, $container_type, $container)
+	{
 		return array_merge(
 			$condition_types,
-			array( 'term_level', 'term_parent', 'term_ancestor' )
+			array('term_level', 'term_parent', 'term_ancestor')
 		);
 	}
 
@@ -338,10 +353,11 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
-	public function filter_user_meta_container_static_condition_types( $condition_types, $container_type, $container ) {
+	public function filter_user_meta_container_static_condition_types($condition_types, $container_type, $container)
+	{
 		return array_merge(
 			$condition_types,
-			array( 'user_id', 'user_capability' )
+			array('user_id', 'user_capability')
 		);
 	}
 
@@ -353,10 +369,11 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
-	public function filter_user_meta_container_dynamic_condition_types( $condition_types, $container_type, $container ) {
+	public function filter_user_meta_container_dynamic_condition_types($condition_types, $container_type, $container)
+	{
 		return array_merge(
 			$condition_types,
-			array( 'user_role' )
+			array('user_role')
 		);
 	}
 
@@ -368,10 +385,11 @@ class Container_Condition_Provider implements ServiceProviderInterface {
 	 * @param  \Carbon_Fields\Container\Container $container
 	 * @return array<string>
 	 */
-	public function filter_theme_options_container_static_condition_types( $condition_types, $container_type, $container ) {
+	public function filter_theme_options_container_static_condition_types($condition_types, $container_type, $container)
+	{
 		return array_merge(
 			$condition_types,
-			array( 'blog_id' )
+			array('blog_id')
 		);
 	}
 }

--- a/tests/unit-tests/Container/Fulfillable/Translator/ArrayTranslatorTest.php
+++ b/tests/unit-tests/Container/Fulfillable/Translator/ArrayTranslatorTest.php
@@ -8,67 +8,74 @@ use Carbon_Fields\Exception\Incorrect_Syntax_Exception;
 
 /**
  * WARNING: the array translator produces logically identical results but not 100% identical representations when dealing with nested collections
- * 
+ *
  * @coversDefaultClass Carbon_Fields\Container\Fulfillable\Translator\Array_Translator
  */
-class ArrayTranslatorTest extends WP_UnitTestCase {
+class ArrayTranslatorTest extends WP_UnitTestCase
+{
 	public $subject;
 
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		$ioc = new PimpleContainer();
 
 		/* Conditions */
-		$ioc['container_condition_factory'] = function( $ioc ) {
-			return new ConditionFactory( $ioc['container_conditions'] );
+		$ioc['container_condition_factory'] = function ($ioc) {
+			return new ConditionFactory($ioc['container_conditions']);
 		};
-		
-		$ioc['container_condition_fulfillable_collection'] = $ioc->factory( function( $ioc ) {
-			return new Fulfillable_Collection( $ioc['container_condition_factory'], $ioc['container_condition_translator_array'] );
-		} );
 
-		$ioc['container_conditions'] = function() {
+		$ioc['container_condition_fulfillable_collection'] = $ioc->factory(function ($ioc) {
+			return new Fulfillable_Collection($ioc['container_condition_factory'], $ioc['container_condition_translator_array']);
+		});
+
+		$ioc['container_conditions'] = function () {
 			return new PimpleContainer();
 		};
 
 		$cc_ioc = $ioc['container_conditions'];
 
-		$cc_ioc['post_id'] = $cc_ioc->factory( function( $cc_ioc ) use ( $ioc ) {
+		$cc_ioc['post_id'] = $cc_ioc->factory(function ($cc_ioc) use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Post_ID_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['generic'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
 			return $condition;
-		} );
-		$cc_ioc['post_type'] = $cc_ioc->factory( function( $cc_ioc ) use ( $ioc ) {
+		});
+		$cc_ioc['post_status'] = $cc_ioc->factory(function ($cc_ioc) use ($ioc) {
+			$condition = new \Carbon_Fields\Container\Condition\Post_Status_Condition();
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['generic']);
+			return $condition;
+		});
+		$cc_ioc['post_type'] = $cc_ioc->factory(function ($cc_ioc) use ($ioc) {
 			$condition = new \Carbon_Fields\Container\Condition\Post_Type_Condition();
-			$condition->set_comparers( $ioc['container_condition_comparer_collections']['nonscalar'] );
+			$condition->set_comparers($ioc['container_condition_comparer_collections']['nonscalar']);
 			return $condition;
-		} );
+		});
 
 		/* Comparers */
-		$ioc['container_condition_comparers'] = function( $ioc ) {
+		$ioc['container_condition_comparers'] = function ($ioc) {
 			return new PimpleContainer();
 		};
 
-		$ioc['container_condition_comparers']['equality'] = function() {
+		$ioc['container_condition_comparers']['equality'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Equality_Comparer();
 		};
 
-		$ioc['container_condition_comparers']['contain'] = function() {
+		$ioc['container_condition_comparers']['contain'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Contain_Comparer();
 		};
 
-		$ioc['container_condition_comparers']['scalar'] = function() {
+		$ioc['container_condition_comparers']['scalar'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Scalar_Comparer();
 		};
 
-		$ioc['container_condition_comparers']['custom'] = function() {
+		$ioc['container_condition_comparers']['custom'] = function () {
 			return new \Carbon_Fields\Container\Condition\Comparer\Custom_Comparer();
 		};
 
-		$ioc['container_condition_comparer_collections'] = function( $ioc ) {
+		$ioc['container_condition_comparer_collections'] = function ($ioc) {
 			return new PimpleContainer();
 		};
 
-		$ioc['container_condition_comparer_collections']['generic'] = function( $cccc_ioc ) use ( $ioc ) {
+		$ioc['container_condition_comparer_collections']['generic'] = function ($cccc_ioc) use ($ioc) {
 			return array(
 				$ioc['container_condition_comparers']['equality'],
 				$ioc['container_condition_comparers']['contain'],
@@ -76,7 +83,7 @@ class ArrayTranslatorTest extends WP_UnitTestCase {
 				$ioc['container_condition_comparers']['custom'],
 			);
 		};
-		$ioc['container_condition_comparer_collections']['nonscalar'] = function( $cccc_ioc ) use ( $ioc ) {
+		$ioc['container_condition_comparer_collections']['nonscalar'] = function ($cccc_ioc) use ($ioc) {
 			return array(
 				$ioc['container_condition_comparers']['equality'],
 				$ioc['container_condition_comparers']['contain'],
@@ -85,16 +92,17 @@ class ArrayTranslatorTest extends WP_UnitTestCase {
 		};
 
 		/* Translators */
-		$ioc['container_condition_translator_array'] = function( $ioc ) {
-			return new \Carbon_Fields\Container\Fulfillable\Translator\Array_Translator( $ioc['container_condition_factory'] );
+		$ioc['container_condition_translator_array'] = function ($ioc) {
+			return new \Carbon_Fields\Container\Fulfillable\Translator\Array_Translator($ioc['container_condition_factory']);
 		};
 
-		\Carbon_Fields\Carbon_Fields::instance()->install( $ioc );
+		\Carbon_Fields\Carbon_Fields::instance()->install($ioc);
 
 		$this->subject = $ioc['container_condition_translator_array'];
 	}
 
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		M::close();
 		$this->subject = null;
 	}
@@ -102,46 +110,49 @@ class ArrayTranslatorTest extends WP_UnitTestCase {
 	/**
 	 * @covers ::fulfillable_to_foreign
 	 */
-	public function testFulfillableToForeignWithCondition() {
-		$factory = \Carbon_Fields\Carbon_Fields::resolve( 'container_condition_factory' );
-		$condition = $factory->make( 'post_type' );
-		$condition->set_comparison_operator( '!=' );
-		$condition->set_value( 'post' );
+	public function testFulfillableToForeignWithCondition()
+	{
+		$factory = \Carbon_Fields\Carbon_Fields::resolve('container_condition_factory');
+		$condition = $factory->make('post_type');
+		$condition->set_comparison_operator('!=');
+		$condition->set_value('post');
 
 		$expected = array(
 			'type' => 'post_type',
 			'compare' => '!=',
 			'value' => 'post',
 		);
-		$received = $this->subject->fulfillable_to_foreign( $condition );
-		$this->assertSame( $expected, $received );
+		$received = $this->subject->fulfillable_to_foreign($condition);
+		$this->assertSame($expected, $received);
 	}
 
 	/**
 	 * @covers ::foreign_to_fulfillable
 	 */
-	public function testForeignToFulfillableWithCondition() {
-		$factory = \Carbon_Fields\Carbon_Fields::resolve( 'container_condition_factory' );
-		$condition = $factory->make( 'post_type' );
-		$condition->set_comparison_operator( '!=' );
-		$condition->set_value( 'post' );
+	public function testForeignToFulfillableWithCondition()
+	{
+		$factory = \Carbon_Fields\Carbon_Fields::resolve('container_condition_factory');
+		$condition = $factory->make('post_type');
+		$condition->set_comparison_operator('!=');
+		$condition->set_value('post');
 
 		$expected = $condition;
-		$received = $this->subject->foreign_to_fulfillable( array(
+		$received = $this->subject->foreign_to_fulfillable(array(
 			'type' => 'post_type',
 			'compare' => '!=',
 			'value' => 'post',
-		) );
-		$this->assertEquals( $expected, $received );
+		));
+		$this->assertEquals($expected, $received);
 	}
 
 	/**
 	 * @covers ::fulfillable_to_foreign
 	 */
-	public function testFulfillableToForeignWithCollection() {
-		$fulfillable = \Carbon_Fields\Carbon_Fields::resolve( 'container_condition_fulfillable_collection' );
-		$fulfillable->where( 'post_type', '!=', 'post' );
-		$fulfillable->where( 'post_id', '!=', 1 );
+	public function testFulfillableToForeignWithCollection()
+	{
+		$fulfillable = \Carbon_Fields\Carbon_Fields::resolve('container_condition_fulfillable_collection');
+		$fulfillable->where('post_type', '!=', 'post');
+		$fulfillable->where('post_id', '!=', 1);
 
 		$expected = array(
 			'relation' => 'AND',
@@ -156,20 +167,21 @@ class ArrayTranslatorTest extends WP_UnitTestCase {
 				'value' => 1,
 			),
 		);
-		$received = $this->subject->fulfillable_to_foreign( $fulfillable );
-		$this->assertSame( $expected, $received );
+		$received = $this->subject->fulfillable_to_foreign($fulfillable);
+		$this->assertSame($expected, $received);
 	}
 
 	/**
 	 * @covers ::foreign_to_fulfillable
 	 */
-	public function testForeignToFulfillableWithCollection() {
-		$fulfillable = \Carbon_Fields\Carbon_Fields::resolve( 'container_condition_fulfillable_collection' );
-		$fulfillable->where( 'post_type', '!=', 'post' );
-		$fulfillable->where( 'post_id', '!=', 1 );
+	public function testForeignToFulfillableWithCollection()
+	{
+		$fulfillable = \Carbon_Fields\Carbon_Fields::resolve('container_condition_fulfillable_collection');
+		$fulfillable->where('post_type', '!=', 'post');
+		$fulfillable->where('post_id', '!=', 1);
 
 		$expected = $fulfillable;
-		$received = $this->subject->foreign_to_fulfillable( array(
+		$received = $this->subject->foreign_to_fulfillable(array(
 			'relation' => 'AND',
 			array(
 				'type' => 'post_type',
@@ -181,20 +193,21 @@ class ArrayTranslatorTest extends WP_UnitTestCase {
 				'compare' => '!=',
 				'value' => 1,
 			),
-		) );
-		$this->assertEquals( $expected, $received );
+		));
+		$this->assertEquals($expected, $received);
 	}
 
 	/**
 	 * @covers ::fulfillable_to_foreign
 	 */
-	public function testFulfillableToForeignWithNestedCollection() {
-		$fulfillable = \Carbon_Fields\Carbon_Fields::resolve( 'container_condition_fulfillable_collection' );
-		$fulfillable->where( 'post_type', '!=', 'post' );
-		$fulfillable->where( function( $c ) {
-			$c->where( 'post_id', '!=', 1 );
-			$c->or_where( 'post_id', '!=', 2 );
-		} );
+	public function testFulfillableToForeignWithNestedCollection()
+	{
+		$fulfillable = \Carbon_Fields\Carbon_Fields::resolve('container_condition_fulfillable_collection');
+		$fulfillable->where('post_type', '!=', 'post');
+		$fulfillable->where(function ($c) {
+			$c->where('post_id', '!=', 1);
+			$c->or_where('post_id', '!=', 2);
+		});
 
 		$expected = array(
 			'relation' => 'AND',
@@ -223,23 +236,24 @@ class ArrayTranslatorTest extends WP_UnitTestCase {
 				),
 			),
 		);
-		$received = $this->subject->fulfillable_to_foreign( $fulfillable );
-		$this->assertSame( $expected, $received );
+		$received = $this->subject->fulfillable_to_foreign($fulfillable);
+		$this->assertSame($expected, $received);
 	}
 
 	/**
 	 * @covers ::foreign_to_fulfillable
 	 */
-	public function testForeignToFulfillableWithNestedCollection() {
-		$fulfillable = \Carbon_Fields\Carbon_Fields::resolve( 'container_condition_fulfillable_collection' );
-		$fulfillable->where( 'post_type', '!=', 'post' );
-		$fulfillable->where( function( $c ) {
-			$c->or_where( 'post_id', '!=', 1 );
-			$c->or_where( 'post_id', '!=', 2 );
-		} );
+	public function testForeignToFulfillableWithNestedCollection()
+	{
+		$fulfillable = \Carbon_Fields\Carbon_Fields::resolve('container_condition_fulfillable_collection');
+		$fulfillable->where('post_type', '!=', 'post');
+		$fulfillable->where(function ($c) {
+			$c->or_where('post_id', '!=', 1);
+			$c->or_where('post_id', '!=', 2);
+		});
 
 		$expected = $fulfillable;
-		$received = $this->subject->foreign_to_fulfillable( array(
+		$received = $this->subject->foreign_to_fulfillable(array(
 			'relation' => 'AND',
 			array(
 				'type' => 'post_type',
@@ -259,7 +273,7 @@ class ArrayTranslatorTest extends WP_UnitTestCase {
 					'value' => 2,
 				),
 			),
-		) );
-		$this->assertEquals( $expected, $received );
+		));
+		$this->assertEquals($expected, $received);
 	}
 }


### PR DESCRIPTION
Added support for the post_status condition. This allows adding a post_status (e.g., draft, publish, etc.) to the 'where' clauses on the container.

```
Container::make('post_meta', 'My container')
	->where('post_type', '=', 'book')
	->where('post_status', '=', 'publish')
	->add_fields(array(

		Field::make('text', 'book_field1', __('My field only visible on published books'),
	));
```
